### PR TITLE
Small fixes

### DIFF
--- a/worlds/dark_souls_3/Options.py
+++ b/worlds/dark_souls_3/Options.py
@@ -115,7 +115,7 @@ class RandomizeBossSoulLocations(DefaultOnToggle):
     "Exclude Locations" option. It does _not_ cause the locations not be
     randomized unless "Excluded Locations" is also set to "Unrandomized".
     """
-    display_name = "Randomize Key Locations"
+    display_name = "Randomize Boss Soul Locations"
 
 
 class RandomizeNPCLocations(DefaultOnToggle):

--- a/worlds/dark_souls_3/Options.py
+++ b/worlds/dark_souls_3/Options.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 import json
 import typing
 
-from Options import Choice, DeathLink, DefaultOnToggle, ExcludeLocations, ItemDict, Option, PerGameCommonOptions, Range, Toggle, VerifyKeys
+from Options import Choice, DeathLink, DefaultOnToggle, ExcludeLocations, ItemDict, Option, PerGameCommonOptions, Range, NamedRange, Toggle, VerifyKeys
 
 
 class ExcludedLocationsOption(Choice):
@@ -233,7 +233,7 @@ class RandomizeInfusionOption(Toggle):
     display_name = "Randomize Infusion"
 
 
-class RandomizeInfusionPercentageOption(Range):
+class RandomizeInfusionPercentageOption(NamedRange):
     """The percentage of weapons/shields in the pool to be infused if Randomize Infusion is toggled"""
     display_name = "Percentage of Infused Weapons"
     range_start = 0

--- a/worlds/dark_souls_3/Options.py
+++ b/worlds/dark_souls_3/Options.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 import json
 import typing
 
-from Options import Choice, DeathLink, DefaultOnToggle, ExcludeLocations, ItemDict, Option, PerGameCommonOptions, Range, NamedRange, Toggle, VerifyKeys
+from Options import Choice, DeathLink, DefaultOnToggle, ExcludeLocations, ItemDict, NamedRange, Option, PerGameCommonOptions, Range, Toggle, VerifyKeys
 
 
 class ExcludedLocationsOption(Choice):

--- a/worlds/dark_souls_3/__init__.py
+++ b/worlds/dark_souls_3/__init__.py
@@ -253,8 +253,8 @@ class DarkSouls3World(World):
             if self._is_location_available(location):
                 new_location = DarkSouls3Location(self.player, location, new_region)
                 if (
-#                    location.missable and self.options.missable_locations == "unimportant"
-#                ) or (
+                    location.missable and self.options.missable_locations == "unimportant"
+                ) or (
                     # Mark Red Eye Orb as missable if Lift Chamber Key isn't randomized, because
                     # the latter is missable by default.
                     not self._is_location_available("FS: Lift Chamber Key - Leonhard")
@@ -1299,6 +1299,7 @@ class DarkSouls3World(World):
                 offworld = self._shuffle(loc for loc in locations if loc.game != "Dark Souls III")
                 onworld = sorted((loc for loc in locations if loc.game == "Dark Souls III"),
                                  key=lambda loc: loc.data.region_value)
+
                 # Give offworld regions the last (best) items within a given sphere
                 for location in onworld + offworld:
                     new_item = self._pop_item(location, item_order)

--- a/worlds/dark_souls_3/__init__.py
+++ b/worlds/dark_souls_3/__init__.py
@@ -778,8 +778,6 @@ class DarkSouls3World(World):
             "CD: Black Eye Orb - Rosaria from Leonhard's quest",
         ], "Pale Tongue")
 
-        self._add_location_rule("CD: Black Eye Orb - Rosaria from Leonhard's quest", "Lift Chamber Key")
-
         self._add_location_rule([
             f"FS: {item} - shop after killing Leonhard"
             for item in ["Leonhard's Garb", "Leonhard's Gauntlets", "Leonhard's Trousers"]

--- a/worlds/dark_souls_3/__init__.py
+++ b/worlds/dark_souls_3/__init__.py
@@ -446,7 +446,7 @@ class DarkSouls3World(World):
                           state.has("Cinders of a Lord - Lothric Prince", self.player))
 
         if self.options.late_basin_of_vows:
-            self._add_entrance_rule("Lothric Castle", "Small Lothric Banner")
+            self._add_entrance_rule("Lothric Castle", lambda state: state.can_reach("Go To Road of Sacrifices", "Entrance", self.player))
 
         # DLC Access Rules Below
         if self.options.enable_dlc:
@@ -468,6 +468,7 @@ class DarkSouls3World(World):
         self._add_location_rule("ID: Bellowing Dragoncrest Ring - drop from B1 towards pit",
                                 "Jailbreaker's Key")
         self._add_location_rule("ID: Covetous Gold Serpent Ring - Siegward's cell", "Old Cell Key")
+        self._add_location_rule("ID: Titanite Slab - Siegward", "Old Cell Key")
         self._add_location_rule(
             "UG: Hornet Ring - environs, right of main path after killing FK boss",
             "Small Lothric Banner"
@@ -554,7 +555,7 @@ class DarkSouls3World(World):
         for (soul, soul_name, items) in transpositions:
             self._add_location_rule([
                 f"FS: {item} - Ludleth for {soul_name}" for item in items
-            ], lambda state: (
+            ], lambda state, soul=soul: (
                 state.has(soul, self.player) and state.has("Transposing Kiln", self.player)
             ))
 
@@ -569,7 +570,7 @@ class DarkSouls3World(World):
             "FS: Hawkwood's Swordgrass - Andre after gesture in AP summit"
         ], "Twinkling Dragon Torso Stone")
 
-        # Shop unlocks:
+        # Shop unlocks
         shop_unlocks = {
             "Cornyx": [
                 (
@@ -680,6 +681,8 @@ class DarkSouls3World(World):
             "ID: Prisoner Chief's Ashes - B2 near, locked cell by stairs",
             "Jailer's Key Ring"
         )
+        
+        # Cornyx
         self._add_location_rule([
             "US: Old Sage's Blindfold - kill Cornyx", "US: Cornyx's Garb - kill Cornyx",
             "US: Cornyx's Wrap - kill Cornyx", "US: Cornyx's Skirt - kill Cornyx"
@@ -687,6 +690,63 @@ class DarkSouls3World(World):
             state.has("Great Swamp Pyromancy Tome", self.player)
             and state.has("Carthus Pyromancy Tome", self.player)
             and state.has("Izalith Pyromancy Tome", self.player)
+        ))
+
+        # Irina
+        self._add_location_rule([
+            "US: Tower Key - kill Irina"
+        ], lambda state: (
+            state.has("Braille Divine Tome of Carim", self.player)
+            and state.has("Braille Divine Tome of Lothric", self.player)
+        ))
+
+        # Orbeck
+        self._add_location_rule([
+            "FS: Morion Blade - Yuria for Orbeck's Ashes",
+            "FS: Clandestine Coat - shop with Orbeck's Ashes"
+        ], lambda state: (
+            state.has("Golden Scroll", self.player)
+            and state.has("Logan's Scroll", self.player)
+            and state.has("Crystal Scroll", self.player)
+            and state.has("Sage's Scroll", self.player)
+        ))
+
+        # Karla
+        self._add_location_rule([
+            "FS: Karla's Trousers - kill Karla",
+            "FS: Karla's Pointed Hat - kill Karla",
+            "FS: Karla's Gloves - kill Karla",
+            "FS: Karla's Coat - kill Karla"
+        ], lambda state: (
+            state.has("Deep Braille Divine Tome", self.player)
+            and state.has("Londor Braille Divine Tome", self.player)
+            and state.has("Quelana Pyromancy Tome", self.player)
+            and state.has("Grave Warden Pyromancy Tome", self.player)
+        ))
+
+        # Patches
+        self._add_location_rule([
+            "CD: Winged Spear - kill Patches"
+        ], lambda state: (
+            state.has("Small Doll", self.player)
+            and state.has("Basin of Vows", self.player)
+            and state.has("Loretta's Bone", self.player)
+            and state.has("Tower Key", self.player)
+            and state.has("Cell Key", self.player)
+        ))
+
+        self._add_location_rule([
+            "FS: Rusted Gold Coin - don't forgive Patches"
+        ], lambda state: (
+            state.has("Tower Key", self.player)
+        ))
+
+        # Leonhard
+        self._add_location_rule([
+            "CD: Black Eye Orb - Rosaria from Leonhard's quest"
+        ], lambda state: (
+            state.has("Pale Tongue", self.player)
+            and state.has("Lift Chamber Key", self.player)
         ))
 
         # Make sure that the player can keep Orbeck around by giving him at least one scroll
@@ -708,7 +768,7 @@ class DarkSouls3World(World):
         # Lump Soul of the Dancer in with LC for locations that should not be reachable
         # before having access to US. (Prevents requiring getting Basin to fight Dancer to get SLB to go to US)
         if self.options.late_basin_of_vows:
-            self._add_location_rule("HWL: Soul of the Dancer", "Small Lothric Banner")
+            self._add_location_rule("HWL: Soul of the Dancer", lambda state: state.can_reach("Go To Road of Sacrifices", "Entrance", self.player))
             # This isn't really necessary, but it ensures that the game logic knows players will
             # want to do Lothric Castle after at least being _able_ to access Catacombs. This is
             # useful for smooth item placement.

--- a/worlds/dark_souls_3/__init__.py
+++ b/worlds/dark_souls_3/__init__.py
@@ -569,7 +569,7 @@ class DarkSouls3World(World):
             "FS: Hawkwood's Swordgrass - Andre after gesture in AP summit"
         ], "Twinkling Dragon Torso Stone")
 
-        # Shop unlocks
+        # Shop unlocks:
         shop_unlocks = {
             "Cornyx": [
                 (


### PR DESCRIPTION
## What is this fixing or adding?

* Some of the logic for NPCs, in particular killing Irina, Orbeck, Karla, and Patches. And one part of Leonhard's questline.

* Changes the Transposing Kiln to no longer have a lambda variable capture error so souls are evaluated properly during the loop.

* Changes the late_basin option so that instead of Small Lothric Banner being required, reaching Road of Sacrifices is required (because RoS requires Transposing Kiln and Pyromancy Flame, but Lothric Castle does not)

## How was this tested?

Some generations (will want to do a lot more)