### PR TITLE
Various small fixes

### DIFF
--- a/worlds/dark_souls_3/Bosses.py
+++ b/worlds/dark_souls_3/Bosses.py
@@ -238,7 +238,13 @@ all_bosses = [
         "RC: Soul of Slave Knight Gael",
         "RC: Blood of the Dark Soul - end boss drop",
     }),
-    DS3BossInfo("Lords of Cinder", 4100800),
+    DS3BossInfo("Lords of Cinder", 4100800, locations = {
+        "KFF: Soul of the Lords",
+        "FS: Billed Mask - Yuria after killing KFF boss",
+        "FS: Black Dress - Yuria after killing KFF boss",
+        "FS: Black Gauntlets - Yuria after killing KFF boss",
+        "FS: Black Leggings - Yuria after killing KFF boss"
+    }),
 ]
 
 default_yhorm_location = DS3BossInfo("Yhorm the Giant", 3900800, locations = {

--- a/worlds/dark_souls_3/Bosses.py
+++ b/worlds/dark_souls_3/Bosses.py
@@ -146,6 +146,7 @@ all_bosses = [
         "UG: Ring of Steel Protection+1 - environs, behind bell tower",
         "FS: Ring of Sacrifice - Yuria shop",
         "UG: Ember - shop",
+        "UG: Priestess Ring - shop",
         "UG: Wolf Knight Helm - shop after killing FK boss",
         "UG: Wolf Knight Armor - shop after killing FK boss",
         "UG: Wolf Knight Gauntlets - shop after killing FK boss",

--- a/worlds/dark_souls_3/Items.py
+++ b/worlds/dark_souls_3/Items.py
@@ -179,7 +179,9 @@ class DS3ItemData():
             DS3ItemCategory.SOUL: "Small Souls",
             DS3ItemCategory.UPGRADE: "Upgrade",
             DS3ItemCategory.HEALING: "Healing",
-        }[default_item.category])
+        }[self.category])
+
+        return names
 
     def counts(self, counts: List[int]) -> Generator["DS3ItemData", None, None]:
         """Returns an iterable of copies of this item with the given counts."""
@@ -1687,6 +1689,10 @@ item_descriptions = {
 
 
 _all_items = _vanilla_items + _dlc_items
+
+for item_data in _all_items:
+  for group_name in item_data.item_groups():
+    item_name_groups[group_name].add(item_data.name)
 
 filler_item_names = [item_data.name for item_data in _all_items if item_data.filler]
 item_dictionary = {item_data.name: item_data for item_data in _all_items}

--- a/worlds/dark_souls_3/Locations.py
+++ b/worlds/dark_souls_3/Locations.py
@@ -1958,13 +1958,13 @@ location_tables = {
 
         # Shrine Handmaid after killing Anri or completing their quest
         DS3LocationData("FS: Elite Knight Helm - shop after Anri quest", "Elite Knight Helm",
-                        missable = True, npc = True, shop = True),
+                        npc = True, shop = True),
         DS3LocationData("FS: Elite Knight Armor - shop after Anri quest", "Elite Knight Armor",
-                        missable = True, npc = True, shop = True),
+                        npc = True, shop = True),
         DS3LocationData("FS: Elite Knight Gauntlets - shop after Anri quest",
-                        "Elite Knight Gauntlets", missable = True, npc = True, shop = True),
+                        "Elite Knight Gauntlets", npc = True, shop = True),
         DS3LocationData("FS: Elite Knight Leggings - shop after Anri quest",
-                        "Elite Knight Leggings", missable = True, npc = True, shop = True),
+                        "Elite Knight Leggings", npc = True, shop = True),
 
         # Ringfinger Leonhard (quest or kill)
         DS3LocationData("AL: Crescent Moon Sword - Leonhard drop", "Crescent Moon Sword",

--- a/worlds/dark_souls_3/Locations.py
+++ b/worlds/dark_souls_3/Locations.py
@@ -2646,8 +2646,7 @@ location_tables = {
         DS3LocationData("PW2 -> DH", None),
 
         # Corvian Settler after killing Friede
-        DS3LocationData("PW1: Titanite Slab - Corvian", "Titanite Slab", missable = True,
-                        npc = True),
+        DS3LocationData("PW1: Titanite Slab - Corvian", "Titanite Slab", npc = True),
 
         # Shrine Handmaid after killing Sister Friede
         DS3LocationData("FS: Ordained Hood - shop after killing PW2 boss", "Ordained Hood",

--- a/worlds/dark_souls_3/Options.py
+++ b/worlds/dark_souls_3/Options.py
@@ -346,7 +346,7 @@ class RandomEnemyPresetOption(Option[typing.Dict[str, typing.Any]], VerifyKeys):
     supports_weighting = False
     default = {}
 
-    valid_keys: ["Description", "RecommendFullRandomization", "RecommendNoEnemyProgression",
+    valid_keys = ["Description", "RecommendFullRandomization", "RecommendNoEnemyProgression",
                  "OopsAll", "Boss", "Miniboss", "Basic", "BuffBasicEnemiesAsBosses",
                  "DontRandomize", "RemoveSource", "Enemies"]
 

--- a/worlds/dark_souls_3/Options.py
+++ b/worlds/dark_souls_3/Options.py
@@ -312,6 +312,7 @@ class LateBasinOfVowsOption(Toggle):
     """This option makes it so the Basin of Vows is still randomized, but guarantees you that you wont have to venture into Lothric Castle to find your Small Lothric Banner to get out of High Wall of Lothric. So you may find Basin of Vows early, but you wont have to fight Dancer to find your Small Lothric Banner."""
     display_name = "Late Basin of Vows"
 
+
 class LateDLCOption(Toggle):
     """This option makes it so you are guaranteed to find your Small Doll without having to venture off into the DLC, effectively putting anything in the DLC in logic after finding both Contraption Key and Small Doll, and being able to get into Irithyll of the Boreal Valley."""
     display_name = "Late DLC"

--- a/worlds/dark_souls_3/Options.py
+++ b/worlds/dark_souls_3/Options.py
@@ -310,7 +310,7 @@ class EarlySmallLothricBanner(Choice):
 
 class LateBasinOfVowsOption(Toggle):
     """This option makes it so the Basin of Vows is still randomized, but guarantees you that you wont have to venture into Lothric Castle to find your Small Lothric Banner to get out of High Wall of Lothric. So you may find Basin of Vows early, but you wont have to fight Dancer to find your Small Lothric Banner."""
-
+    display_name = "Late Basin of Vows"
 
 class LateDLCOption(Toggle):
     """This option makes it so you are guaranteed to find your Small Doll without having to venture off into the DLC, effectively putting anything in the DLC in logic after finding both Contraption Key and Small Doll, and being able to get into Irithyll of the Boreal Valley."""

--- a/worlds/dark_souls_3/Options.py
+++ b/worlds/dark_souls_3/Options.py
@@ -308,17 +308,8 @@ class EarlySmallLothricBanner(Choice):
     default = option_off
 
 
-class LateBasinOfVowsOption(Choice):
-    """This option makes it so the Basin of Vows is still randomized, but you can choose the requirements to venture into Lothric Castle.
-    "Off": You may have to enter Lothric Castle and the areas beyond it before finding your Small Lothric Banner.
-    "After Small Lothric Banner": You are guaranteed to find your Small Lothric Banner before needing to enter Lothric Castle.
-    "After Small Doll": You are guaranteed to find your Small Lothric Banner and your Small Doll before needing to enter Lothric Castle."""
-    display_name = "Late Basin of Vows"
-    option_off = 0
-    alias_false = 0
-    option_after_small_lothric_banner = 1
-    alias_true = 1
-    option_after_small_doll = 2
+class LateBasinOfVowsOption(Toggle):
+    """This option makes it so the Basin of Vows is still randomized, but guarantees you that you wont have to venture into Lothric Castle to find your Small Lothric Banner to get out of High Wall of Lothric. So you may find Basin of Vows early, but you wont have to fight Dancer to find your Small Lothric Banner."""
 
 
 class LateDLCOption(Toggle):

--- a/worlds/dark_souls_3/Options.py
+++ b/worlds/dark_souls_3/Options.py
@@ -308,9 +308,17 @@ class EarlySmallLothricBanner(Choice):
     default = option_off
 
 
-class LateBasinOfVowsOption(Toggle):
-    """This option makes it so the Basin of Vows is still randomized, but guarantees you that you wont have to venture into Lothric Castle to find your Small Lothric Banner to get out of High Wall of Lothric. So you may find Basin of Vows early, but you wont have to fight Dancer to find your Small Lothric Banner."""
+class LateBasinOfVowsOption(Choice):
+    """This option makes it so the Basin of Vows is still randomized, but you can choose the requirements to venture into Lothric Castle.
+    "Off": You may have to enter Lothric Castle and the areas beyond it before finding your Small Lothric Banner.
+    "After Small Lothric Banner": You are guaranteed to find your Small Lothric Banner before needing to enter Lothric Castle.
+    "After Small Doll": You are guaranteed to find your Small Lothric Banner and your Small Doll before needing to enter Lothric Castle."""
     display_name = "Late Basin of Vows"
+    option_off = 0
+    alias_false = 0
+    option_after_small_lothric_banner = 1
+    alias_true = 1
+    option_after_small_doll = 2
 
 
 class LateDLCOption(Toggle):

--- a/worlds/dark_souls_3/__init__.py
+++ b/worlds/dark_souls_3/__init__.py
@@ -498,9 +498,13 @@ class DarkSouls3World(World):
         self._add_location_rule("ID: Bellowing Dragoncrest Ring - drop from B1 towards pit",
                                 "Jailbreaker's Key")
         self._add_location_rule("ID: Covetous Gold Serpent Ring - Siegward's cell", "Old Cell Key")
-        self._add_location_rule(
+        self._add_location_rule([
             "UG: Hornet Ring - environs, right of main path after killing FK boss",
-            lambda state: self._can_get(state, "FK: Cinders of a Lord - Abyss Watcher"),
+            "UG: Wolf Knight Helm - shop after killing FK boss",
+            "UG: Wolf Knight Armor - shop after killing FK boss",
+            "UG: Wolf Knight Gauntlets - shop after killing FK boss",
+            "UG: Wolf Knight Leggings - shop after killing FK boss"
+        ], lambda state: self._can_get(state, "FK: Cinders of a Lord - Abyss Watcher")
         )
         self._add_location_rule(
             "ID: Prisoner Chief's Ashes - B2 near, locked cell by stairs",
@@ -793,9 +797,10 @@ class DarkSouls3World(World):
 
         # Hawkwood only leaves after defating Abyss Watchers, Curse-Rotted Greatwood, Deacons of the Deep and Crystal Sage
         # All of these are covered by the Farron Keep placement except for Abyss Watchers
-        self._add_location_rule(
-            "FS: Hawkwood's Shield - gravestone after Hawkwood leaves",
-            lambda state: self._can_get(state, "FK: Cinders of a Lord - Abyss Watcher")
+        self._add_location_rule([
+                "FS: Hawkwood's Shield - gravestone after Hawkwood leaves",
+                "FS: Farron Ring - Hawkwood"
+        ], lambda state: self._can_get(state, "FK: Cinders of a Lord - Abyss Watcher")
         )
         
         # After Hawkwood leaves and once you have the Torso Stone, you can fight him for dragon
@@ -936,6 +941,10 @@ class DarkSouls3World(World):
         # before killing Abyss Watchers.
         self._add_location_rule("FK: Soul of the Blood of the Wolf", self._has_any_scroll)
         self._add_location_rule("FK: Cinders of a Lord - Abyss Watcher", self._has_any_scroll)
+        self._add_location_rule("FS: Undead Legion Helm - shop after killing FK boss", self._has_any_scroll)
+        self._add_location_rule("FS: Undead Legion Armor - shop after killing FK boss", self._has_any_scroll)
+        self._add_location_rule("FS: Undead Legion Gauntlet - shop after killing FK boss", self._has_any_scroll)
+        self._add_location_rule("FS: Undead Legion Leggings - shop after killing FK boss", self._has_any_scroll)
         self._add_entrance_rule("Catacombs of Carthus", self._has_any_scroll)
         # Not really necessary but ensures players can decide which way to go
         if self.options.enable_dlc:

--- a/worlds/dark_souls_3/__init__.py
+++ b/worlds/dark_souls_3/__init__.py
@@ -477,8 +477,6 @@ class DarkSouls3World(World):
                 # useful for smooth item placement.
                 and self._has_any_scroll(state)
             ))
-            if self.options.late_basin_of_vows == "after_small_doll":
-                self._add_entrance_rule("Lothric Castle", "Small Doll")
 
         # DLC Access Rules Below
         if self.options.enable_dlc:
@@ -534,8 +532,6 @@ class DarkSouls3World(World):
                 # useful for smooth item placement.
                 and self._has_any_scroll(state)
             ))
-            if self.options.late_basin_of_vows == "after_small_doll":
-                self._add_location_rule("HWL: Soul of the Dancer", "Small Doll")
 
         self._add_location_rule([
             "LC: Grand Archives Key - by Grand Archives door, after PC and AL bosses",

--- a/worlds/dark_souls_3/__init__.py
+++ b/worlds/dark_souls_3/__init__.py
@@ -453,7 +453,8 @@ class DarkSouls3World(World):
             lambda state: state.has("Cinders of a Lord - Abyss Watcher", self.player) and
                           state.has("Cinders of a Lord - Yhorm the Giant", self.player) and
                           state.has("Cinders of a Lord - Aldrich", self.player) and
-                          state.has("Cinders of a Lord - Lothric Prince", self.player))
+                          state.has("Cinders of a Lord - Lothric Prince", self.player) and
+                          state.has("Transposing Kiln", self.player))
 
         if self.options.late_basin_of_vows:
             self._add_entrance_rule("Lothric Castle", lambda state: (

--- a/worlds/dark_souls_3/__init__.py
+++ b/worlds/dark_souls_3/__init__.py
@@ -286,12 +286,6 @@ class DarkSouls3World(World):
 
             new_region.locations.append(new_location)
 
-        # If we allow useful  items in the excluded locations, we don't want Archipelago's fill
-        # algorithm to consider them excluded because it never allows useful items there. Instead,
-        # we manually add item rules to exclude important items.
-        if self.options.excluded_locations == "unnecessary":
-            self.options.exclude_locations.value.clear()
-
         self.multiworld.regions.append(new_region)
         return new_region
 
@@ -1051,6 +1045,9 @@ class DarkSouls3World(World):
 
     def _add_unnecessary_location_rules(self) -> None:
         """Adds rules for locations that can contain useful but not necessary items."""
+        # If we allow useful  items in the excluded locations, we don't want Archipelago's fill
+        # algorithm to consider them excluded because it never allows useful items there. Instead,
+        # we manually add item rules to exclude important items.
 
         unnecessary_locations = (
             self.options.exclude_locations.value
@@ -1070,6 +1067,9 @@ class DarkSouls3World(World):
                 location,
                 lambda item: not item.advancement
             )
+
+        if self.options.excluded_locations == "unnecessary":
+            self.options.exclude_locations.value.clear()
 
 
     def _add_early_item_rules(self, randomized_items: Set[str]) -> None:

--- a/worlds/dark_souls_3/__init__.py
+++ b/worlds/dark_souls_3/__init__.py
@@ -108,7 +108,7 @@ class DarkSouls3World(World):
                 self.yhorm_location.name == "Iudex Gundyr" or
                 self.yhorm_location.name == "Vordt of the Boreal Valley" or (
                     self.yhorm_location.name == "Dancer of the Boreal Valley" and
-                    not self.multiworld.late_basin_of_vows
+                    not self.options.late_basin_of_vows
                 )
             ):
                 self.multiworld.early_items[self.player]['Storm Ruler'] = 1

--- a/worlds/dark_souls_3/__init__.py
+++ b/worlds/dark_souls_3/__init__.py
@@ -477,6 +477,8 @@ class DarkSouls3World(World):
                 # useful for smooth item placement.
                 and self._has_any_scroll(state)
             ))
+            if self.options.late_basin_of_vows == "after_small_doll":
+                self._add_entrance_rule("Lothric Castle", "Small Doll")
 
         # DLC Access Rules Below
         if self.options.enable_dlc:
@@ -532,6 +534,8 @@ class DarkSouls3World(World):
                 # useful for smooth item placement.
                 and self._has_any_scroll(state)
             ))
+            if self.options.late_basin_of_vows == "after_small_doll":
+                self._add_entrance_rule("Lothric Castle", "Small Doll")
 
         self._add_location_rule([
             "LC: Grand Archives Key - by Grand Archives door, after PC and AL bosses",
@@ -779,12 +783,25 @@ class DarkSouls3World(World):
         ], "Pale Tongue")
 
         self._add_location_rule([
+            "AL: Crescent Moon Sword - Leonhard drop",
+            "AL: Silver Mask - Leonhard drop",
+            "AL: Soul of Rosaria - Leonhard drop"
+        ], "Black Eye Orb")
+
+        self._add_location_rule([
             f"FS: {item} - shop after killing Leonhard"
             for item in ["Leonhard's Garb", "Leonhard's Gauntlets", "Leonhard's Trousers"]
         ], "Black Eye Orb")
 
         ## Hawkwood
 
+        # Hawkwood only leaves after defating Abyss Watchers, Curse-Rotted Greatwood, Deacons of the Deep and Crystal Sage
+        # All of these are covered by the Farron Keep placement except for Abyss Watchers
+        self._add_location_rule(
+            "FS: Hawkwood's Shield - gravestone after Hawkwood leaves",
+            lambda state: self._can_get(state, "FK: Cinders of a Lord - Abyss Watcher")
+        )
+        
         # After Hawkwood leaves and once you have the Torso Stone, you can fight him for dragon
         # stones. Andre will give Swordgrass as a hint as well
         self._add_location_rule([
@@ -916,6 +933,9 @@ class DarkSouls3World(World):
             and state.has("Sage's Scroll", self.player)
         ))
 
+        self._add_location_rule("FS: Pestilent Mist - Orbeck for any scroll", self._has_any_scroll)
+        self._add_location_rule("FS: Young Dragon Ring - Orbeck for one scroll and buying three spells", self._has_any_scroll)
+        
         # Make sure that the player can keep Orbeck around by giving him at least one scroll
         # before killing Abyss Watchers.
         self._add_location_rule("FK: Soul of the Blood of the Wolf", self._has_any_scroll)

--- a/worlds/dark_souls_3/__init__.py
+++ b/worlds/dark_souls_3/__init__.py
@@ -832,6 +832,11 @@ class DarkSouls3World(World):
         self._add_location_rule([
             "FS: Mail Breaker - Sirris for killing Creighton",
             "FS: Silvercat Ring - Sirris for killing Creighton",
+            "IBV: Creighton's Steel Mask - bridge after killing Creighton",
+            "IBV: Mirrah Chain Gloves - bridge after killing Creighton",
+            "IBV: Mirrah Chain Leggings - bridge after killing Creighton",
+            "IBV: Mirrah Chain Mail - bridge after killing Creighton",
+            "IBV: Dragonslayer's Axe - Creighton drop"
         ], lambda state: (
             self._can_get(state, "US: Soul of the Rotted Greatwood")
             and state.has("Dreamchaser's Ashes", self.player)

--- a/worlds/dark_souls_3/__init__.py
+++ b/worlds/dark_souls_3/__init__.py
@@ -112,7 +112,7 @@ class DarkSouls3World(World):
                 )
             ):
                 self.multiworld.early_items[self.player]['Storm Ruler'] = 1
-                self.multiworld.worlds[self.player].options.local_items.value.add('Storm Ruler')
+                self.options.local_items.value.add('Storm Ruler')
         else:
             self.yhorm_location = default_yhorm_location
 
@@ -535,7 +535,7 @@ class DarkSouls3World(World):
                 and self._has_any_scroll(state)
             ))
             if self.options.late_basin_of_vows == "after_small_doll":
-                self._add_entrance_rule("Lothric Castle", "Small Doll")
+                self._add_location_rule("HWL: Soul of the Dancer", "Small Doll")
 
         self._add_location_rule([
             "LC: Grand Archives Key - by Grand Archives door, after PC and AL bosses",

--- a/worlds/dark_souls_3/__init__.py
+++ b/worlds/dark_souls_3/__init__.py
@@ -486,10 +486,8 @@ class DarkSouls3World(World):
             self._add_entrance_rule("Ringed City", "Small Envoy Banner")
 
             if self.options.late_dlc:
-                self._add_entrance_rule(
-                    "Painted World of Ariandel (Before Contraption)",
-                    "Small Doll"
-                )
+                self._add_entrance_rule("Painted World of Ariandel (Before Contraption)", "Small Doll")
+                self._add_entrance_rule("Painted World of Ariandel (Before Contraption)", self._has_any_scroll)
 
         # Define the access rules to some specific locations
         if self._is_location_available("FS: Lift Chamber Key - Leonhard"):

--- a/worlds/dark_souls_3/__init__.py
+++ b/worlds/dark_souls_3/__init__.py
@@ -935,7 +935,7 @@ class DarkSouls3World(World):
 
         self._add_location_rule("FS: Pestilent Mist - Orbeck for any scroll", self._has_any_scroll)
         self._add_location_rule("FS: Young Dragon Ring - Orbeck for one scroll and buying three spells", self._has_any_scroll)
-        
+
         # Make sure that the player can keep Orbeck around by giving him at least one scroll
         # before killing Abyss Watchers.
         self._add_location_rule("FK: Soul of the Blood of the Wolf", self._has_any_scroll)


### PR DESCRIPTION
## What is this fixing or adding?

Fixes some logic for Leonhard's drops, Creighton's drops, Hawkwood leaving, and Orbeck's shop.
Also fixes the logic for locations that require defeating the FK boss which requires any Scroll.
Adds a Scroll requirement for `late_dlc` so you don't have to enter PW1 to get to Catacombs.
Simplifies a `local_items` option getter and fixes a `basin_of_vows` option getter.
Fixes `exclude_locations` (the set) getting cleared before it was used when `excluded_locations` was set to "unnecessary"
Added "UG: Priestess Ring - shop" to be considered after the UG boss.
Added post-final-boss checks to be considered after the KFF boss.
Removes "missable" from the Corvian Titanite Slab in Painted World because it can always be obtained.
Removes "missable" from the Elite Knight Set because it can always be obtained.
Adding Tranposing Kiln requirement to access Kiln of the First Flame so that Ludleth dying doesn't lock out tranpositions.

Also fixes item_groups not working/existing and a `valid_keys` assignment in Random Enemy Preset

## How was this tested?

200 5-DS3 generations and 100 solo generations, read through several spoiler logs.