### PR TITLE
Changing excess progression items to go into start inventory

### DIFF
--- a/worlds/dark_souls_3/__init__.py
+++ b/worlds/dark_souls_3/__init__.py
@@ -1226,7 +1226,8 @@ class DarkSouls3World(World):
 
         if not candidate_locations:
             if not mandatory: return
-            raise Exception(f"No valid locations to place {name}")
+            warning(f"Couldn't place \"{name}\" in a valid location for {self.multiworld.get_player_name(self.player)}. Adding it to starting inventory instead.")
+            self.multiworld.push_precollected(self.create_item(name))
 
         location = self.multiworld.random.choice(candidate_locations)
         location.place_locked_item(item)


### PR DESCRIPTION
## What is this fixing or adding?

Sometimes there would not be enough locations to inject Path of the Dragon or the required Crow trade items. So this adds them to `start_inventory` if that is the case.

There were also cases where Storm Ruler had to be placed early, but it's possible for zero locations to exist. So this adds it to `start_inventory` if that is the case.

## How was this tested?

Many generations and reading playthroughs.