### PR TITLE
Expanded Late Basin of Vows and Late DLC

### DIFF
--- a/worlds/dark_souls_3/Options.py
+++ b/worlds/dark_souls_3/Options.py
@@ -312,7 +312,7 @@ class LateBasinOfVowsOption(Choice):
     """This option makes it so the Basin of Vows is still randomized, but you can choose the requirements to venture into Lothric Castle.
     "Off": You may have to enter Lothric Castle and the areas beyond it before finding your Small Lothric Banner.
     "After Small Lothric Banner": You are guaranteed to find your Small Lothric Banner before needing to enter Lothric Castle.
-    "After Catacombs": You are guranteed to find your Small Lothric Banner and a Scroll to access Catacombs of Carthus and Smouldering Lake before needing to enter Lothric Castle.
+    "After Catacombs": You are guaranteed to find your Small Lothric Banner and a Scroll to access Catacombs of Carthus and Smouldering Lake before needing to enter Lothric Castle.
     "After Small Doll": You are guaranteed to find your Small Lothric Banner, a Scroll, and your Small Doll before needing to enter Lothric Castle."""
     display_name = "Late Basin of Vows"
     option_off = 0
@@ -323,9 +323,17 @@ class LateBasinOfVowsOption(Choice):
     option_after_small_doll = 3
 
 
-class LateDLCOption(Toggle):
-    """This option makes it so you are guaranteed to find your Small Doll without having to venture off into the DLC, effectively putting anything in the DLC in logic after finding both Contraption Key and Small Doll, and being able to get into Irithyll of the Boreal Valley."""
+class LateDLCOption(Choice):
+    """This option makes it so the Small Doll is still randomized, but you can choose the requirements to venture into Painted World of Ariandel.
+    "Off": You may have to enter Ariandel and the areas beyond it before entering Catacombs of Carthus.
+    "After Catacombs": You are guaranteed to find a Scroll to access Catacombs of Carthus and Smouldering Lake before needing to enter Ariandel.
+    "After Small Doll": You are guaranteed to find a Scroll and your Small Doll before needing to enter Ariandel.
+    "After Basin": You are guaranteed to find a Scroll, your Small Doll, and your Basin of Vows before needing to enter Ariandel."""
     display_name = "Late DLC"
+    option_off = 0
+    option_after_catacombs = 1
+    option_after_small_doll = 2
+    option_after_basin = 3
 
 
 class EnableDLCOption(Toggle):

--- a/worlds/dark_souls_3/Options.py
+++ b/worlds/dark_souls_3/Options.py
@@ -312,28 +312,26 @@ class LateBasinOfVowsOption(Choice):
     """This option makes it so the Basin of Vows is still randomized, but you can choose the requirements to venture into Lothric Castle.
     "Off": You may have to enter Lothric Castle and the areas beyond it before finding your Small Lothric Banner.
     "After Small Lothric Banner": You are guaranteed to find your Small Lothric Banner before needing to enter Lothric Castle.
-    "After Catacombs": You are guaranteed to find your Small Lothric Banner and a Scroll to access Catacombs of Carthus and Smouldering Lake before needing to enter Lothric Castle.
-    "After Small Doll": You are guaranteed to find your Small Lothric Banner, a Scroll, and your Small Doll before needing to enter Lothric Castle."""
+    "After Small Doll": You are guaranteed to find your Small Lothric Banner and your Small Doll before needing to enter Lothric Castle."""
     display_name = "Late Basin of Vows"
     option_off = 0
     alias_false = 0
     option_after_small_lothric_banner = 1
-    option_after_catacombs = 2
-    alias_true = 2
-    option_after_small_doll = 3
+    alias_true = 1
+    option_after_small_doll = 2
 
 
 class LateDLCOption(Choice):
     """This option makes it so the Small Doll is still randomized, but you can choose the requirements to venture into Painted World of Ariandel.
-    "Off": You may have to enter Ariandel and the areas beyond it before entering Catacombs of Carthus.
-    "After Catacombs": You are guaranteed to find a Scroll to access Catacombs of Carthus and Smouldering Lake before needing to enter Ariandel.
-    "After Small Doll": You are guaranteed to find a Scroll and your Small Doll before needing to enter Ariandel.
-    "After Basin": You are guaranteed to find a Scroll, your Small Doll, and your Basin of Vows before needing to enter Ariandel."""
+    "Off": You may have to enter Ariandel and the areas beyond it before finding your Small Doll.
+    "After Small Doll": You are guaranteed to find your Small Doll before needing to enter Ariandel.
+    "After Basin": You are guaranteed to find your Small Doll and your Basin of Vows before needing to enter Ariandel."""
     display_name = "Late DLC"
     option_off = 0
-    option_after_catacombs = 1
-    option_after_small_doll = 2
-    option_after_basin = 3
+    alias_false = 0
+    option_after_small_doll = 1
+    alias_true = 1
+    option_after_basin = 2
 
 
 class EnableDLCOption(Toggle):

--- a/worlds/dark_souls_3/Options.py
+++ b/worlds/dark_souls_3/Options.py
@@ -308,9 +308,19 @@ class EarlySmallLothricBanner(Choice):
     default = option_off
 
 
-class LateBasinOfVowsOption(Toggle):
-    """This option makes it so the Basin of Vows is still randomized, but guarantees you that you wont have to venture into Lothric Castle to find your Small Lothric Banner to get out of High Wall of Lothric. So you may find Basin of Vows early, but you wont have to fight Dancer to find your Small Lothric Banner."""
+class LateBasinOfVowsOption(Choice):
+    """This option makes it so the Basin of Vows is still randomized, but you can choose the requirements to venture into Lothric Castle.
+    "Off": You may have to enter Lothric Castle and the areas beyond it before finding your Small Lothric Banner.
+    "After Small Lothric Banner": You are guaranteed to find your Small Lothric Banner before needing to enter Lothric Castle.
+    "After Catacombs": You are guranteed to find your Small Lothric Banner and a Scroll to access Catacombs of Carthus and Smouldering Lake before needing to enter Lothric Castle.
+    "After Small Doll": You are guaranteed to find your Small Lothric Banner, a Scroll, and your Small Doll before needing to enter Lothric Castle."""
     display_name = "Late Basin of Vows"
+    option_off = 0
+    alias_false = 0
+    option_after_small_lothric_banner = 1
+    option_after_catacombs = 2
+    alias_true = 2
+    option_after_small_doll = 3
 
 
 class LateDLCOption(Toggle):

--- a/worlds/dark_souls_3/__init__.py
+++ b/worlds/dark_souls_3/__init__.py
@@ -489,7 +489,6 @@ class DarkSouls3World(World):
                           state.has("Cinders of a Lord - Lothric Prince", self.player) and
                           state.has("Transposing Kiln", self.player))
 
-        self._add_entrance_rule("Lothric Castle", self._has_any_scroll)
         if self.options.late_basin_of_vows:
             self._add_entrance_rule("Lothric Castle", lambda state: (
                 state.has("Small Lothric Banner", self.player)

--- a/worlds/dark_souls_3/__init__.py
+++ b/worlds/dark_souls_3/__init__.py
@@ -428,7 +428,7 @@ class DarkSouls3World(World):
             and data.category.upgrade_level
             # Because we require the Pyromancy Flame to be available early, don't upgrade it so it
             # doesn't get shuffled around by weapon smoothing.
-            and not data.name == "Pyromancy Flame"
+            and not data.name == "Pyromancy FLame"
         ):
             # if the user made an error and set a min higher than the max we default to the max
             max_5 = self.options.max_levels_in_5

--- a/worlds/dark_souls_3/__init__.py
+++ b/worlds/dark_souls_3/__init__.py
@@ -472,11 +472,13 @@ class DarkSouls3World(World):
                     "Pyromancy Flame" not in randomized_items
                     or state.has("Pyromancy Flame", self.player)
                 )
-                # This isn't really necessary, but it ensures that the game logic knows players will
-                # want to do Lothric Castle after at least being _able_ to access Catacombs. This is
-                # useful for smooth item placement.
-                and self._has_any_scroll(state)
             ))
+
+            if self.options.late_basin_of_vows > 1: # After Catacombs
+                self._add_entrance_rule("Lothric Castle", self._has_any_scroll)
+
+            if self.options.late_basin_of_vows > 2: # After Small Doll
+                self._add_entrance_rule("Lothric Castle", "Small Doll")
 
         # DLC Access Rules Below
         if self.options.enable_dlc:
@@ -527,11 +529,13 @@ class DarkSouls3World(World):
                     "Pyromancy Flame" not in randomized_items
                     or state.has("Pyromancy Flame", self.player)
                 )
-                # This isn't really necessary, but it ensures that the game logic knows players will
-                # want to do Lothric Castle after at least being _able_ to access Catacombs. This is
-                # useful for smooth item placement.
-                and self._has_any_scroll(state)
             ))
+
+            if self.options.late_basin_of_vows > 1: # After Catacombs
+                self._add_location_rule("HWL: Soul of the Dancer", self._has_any_scroll)
+
+            if self.options.late_basin_of_vows > 2: # After Small Doll
+                self._add_location_rule("HWL: Soul of the Dancer", "Small Doll")
 
         self._add_location_rule([
             "LC: Grand Archives Key - by Grand Archives door, after PC and AL bosses",

--- a/worlds/dark_souls_3/__init__.py
+++ b/worlds/dark_souls_3/__init__.py
@@ -489,6 +489,7 @@ class DarkSouls3World(World):
                           state.has("Cinders of a Lord - Lothric Prince", self.player) and
                           state.has("Transposing Kiln", self.player))
 
+        self._add_entrance_rule("Lothric Castle", self._has_any_scroll)
         if self.options.late_basin_of_vows:
             self._add_entrance_rule("Lothric Castle", lambda state: (
                 state.has("Small Lothric Banner", self.player)
@@ -502,26 +503,21 @@ class DarkSouls3World(World):
                 )
             ))
 
-            if self.options.late_basin_of_vows > 1: # After Catacombs
-                self._add_entrance_rule("Lothric Castle", self._has_any_scroll)
-
-            if self.options.late_basin_of_vows > 2: # After Small Doll
+            if self.options.late_basin_of_vows > 1: # After Small Doll
                 self._add_entrance_rule("Lothric Castle", "Small Doll")
 
         # DLC Access Rules Below
         if self.options.enable_dlc:
+            self._add_entrance_rule("Painted World of Ariandel (Before Contraption)", self._has_any_scroll)
             self._add_entrance_rule("Painted World of Ariandel (Before Contraption)", "CD -> PW1")
             self._add_entrance_rule("Painted World of Ariandel (After Contraption)", "Contraption Key")
             self._add_entrance_rule("Dreg Heap", "PW2 -> DH")
             self._add_entrance_rule("Ringed City", "Small Envoy Banner")
 
-            if self.options.late_dlc: # After Catacombs
-                self._add_entrance_rule("Painted World of Ariandel (Before Contraption)", self._has_any_scroll)
-
-            if self.options.late_dlc > 1: # After Small Doll
+            if self.options.late_dlc: # After Small Doll
                 self._add_entrance_rule("Painted World of Ariandel (Before Contraption)", "Small Doll")
             
-            if self.options.late_dlc > 2: # After Basin
+            if self.options.late_dlc > 1: # After Basin
                 self._add_entrance_rule("Painted World of Ariandel (Before Contraption)", "Basin of Vows")
 
         # Define the access rules to some specific locations
@@ -552,6 +548,7 @@ class DarkSouls3World(World):
 
         # Lump Soul of the Dancer in with LC for locations that should not be reachable
         # before having access to US. (Prevents requiring getting Basin to fight Dancer to get SLB to go to US)
+        self._add_location_rule("HWL: Soul of the Dancer", self._has_any_scroll)
         if self.options.late_basin_of_vows:
             self._add_location_rule("HWL: Soul of the Dancer", lambda state: (
                 state.has("Small Lothric Banner", self.player)
@@ -565,10 +562,7 @@ class DarkSouls3World(World):
                 )
             ))
 
-            if self.options.late_basin_of_vows > 1: # After Catacombs
-                self._add_location_rule("HWL: Soul of the Dancer", self._has_any_scroll)
-
-            if self.options.late_basin_of_vows > 2: # After Small Doll
+            if self.options.late_basin_of_vows > 1: # After Small Doll
                 self._add_location_rule("HWL: Soul of the Dancer", "Small Doll")
 
         self._add_location_rule([

--- a/worlds/dark_souls_3/__init__.py
+++ b/worlds/dark_souls_3/__init__.py
@@ -994,6 +994,13 @@ class DarkSouls3World(World):
             "UG: Wolf Knight Leggings - shop after killing FK boss",
         ], self._has_any_scroll)
 
+        # Not really necessary but ensures players can decide which way to go
+        if self.options.enable_dlc:
+            self._add_entrance_rule(
+                "Painted World of Ariandel (After Contraption)",
+                self._has_any_scroll
+            )
+
         ## Anri
 
         # Anri only leaves Road of Sacrifices once Deacons is defeated

--- a/worlds/dark_souls_3/__init__.py
+++ b/worlds/dark_souls_3/__init__.py
@@ -519,7 +519,7 @@ class DarkSouls3World(World):
             if self.options.late_dlc:
                 self._add_entrance_rule(
                     "Painted World of Ariandel (Before Contraption)",
-                    lambda state: state.has("Small Doll", self.player) and self._has_any_scroll(state))
+                    lambda state: state.has("Small Doll") and self._has_any_scroll(state))
 
             if self.options.late_dlc > 1: # After Basin
                 self._add_entrance_rule("Painted World of Ariandel (Before Contraption)", "Basin of Vows")

--- a/worlds/dark_souls_3/__init__.py
+++ b/worlds/dark_souls_3/__init__.py
@@ -503,7 +503,7 @@ class DarkSouls3World(World):
                 # This isn't really necessary, but it ensures that the game logic knows players will
                 # want to do Lothric Castle after at least being _able_ to access Catacombs. This is
                 # useful for smooth item placement.
-                and self._has_any_scroll
+                and self._has_any_scroll(state)
             ))
 
             if self.options.late_basin_of_vows > 1: # After Small Doll
@@ -519,7 +519,7 @@ class DarkSouls3World(World):
             if self.options.late_dlc:
                 self._add_entrance_rule(
                     "Painted World of Ariandel (Before Contraption)",
-                    lambda state: state.has("Small Doll", self.player) and self._has_any_scroll)
+                    lambda state: state.has("Small Doll", self.player) and self._has_any_scroll(state))
 
             if self.options.late_dlc > 1: # After Basin
                 self._add_entrance_rule("Painted World of Ariandel (Before Contraption)", "Basin of Vows")
@@ -566,7 +566,7 @@ class DarkSouls3World(World):
                 # This isn't really necessary, but it ensures that the game logic knows players will
                 # want to do Lothric Castle after at least being _able_ to access Catacombs. This is
                 # useful for smooth item placement.
-                and self._has_any_scroll
+                and self._has_any_scroll(state)
             ))
 
             if self.options.late_basin_of_vows > 1: # After Small Doll

--- a/worlds/dark_souls_3/__init__.py
+++ b/worlds/dark_souls_3/__init__.py
@@ -428,7 +428,7 @@ class DarkSouls3World(World):
             and data.category.upgrade_level
             # Because we require the Pyromancy Flame to be available early, don't upgrade it so it
             # doesn't get shuffled around by weapon smoothing.
-            and not data.name == "Pyromancy FLame"
+            and not data.name == "Pyromancy Flame"
         ):
             # if the user made an error and set a min higher than the max we default to the max
             max_5 = self.options.max_levels_in_5
@@ -501,6 +501,10 @@ class DarkSouls3World(World):
                     "Pyromancy Flame" not in randomized_items
                     or state.has("Pyromancy Flame", self.player)
                 )
+                # This isn't really necessary, but it ensures that the game logic knows players will
+                # want to do Lothric Castle after at least being _able_ to access Catacombs. This is
+                # useful for smooth item placement.
+                and self._has_any_scroll
             ))
 
             if self.options.late_basin_of_vows > 1: # After Small Doll
@@ -508,15 +512,16 @@ class DarkSouls3World(World):
 
         # DLC Access Rules Below
         if self.options.enable_dlc:
-            self._add_entrance_rule("Painted World of Ariandel (Before Contraption)", self._has_any_scroll)
             self._add_entrance_rule("Painted World of Ariandel (Before Contraption)", "CD -> PW1")
             self._add_entrance_rule("Painted World of Ariandel (After Contraption)", "Contraption Key")
             self._add_entrance_rule("Dreg Heap", "PW2 -> DH")
             self._add_entrance_rule("Ringed City", "Small Envoy Banner")
 
-            if self.options.late_dlc: # After Small Doll
-                self._add_entrance_rule("Painted World of Ariandel (Before Contraption)", "Small Doll")
-            
+            if self.options.late_dlc:
+                self._add_entrance_rule(
+                    "Painted World of Ariandel (Before Contraption)",
+                    lambda state: state.has("Small Doll", self.player) and self._has_any_scroll)
+
             if self.options.late_dlc > 1: # After Basin
                 self._add_entrance_rule("Painted World of Ariandel (Before Contraption)", "Basin of Vows")
 
@@ -548,7 +553,6 @@ class DarkSouls3World(World):
 
         # Lump Soul of the Dancer in with LC for locations that should not be reachable
         # before having access to US. (Prevents requiring getting Basin to fight Dancer to get SLB to go to US)
-        self._add_location_rule("HWL: Soul of the Dancer", self._has_any_scroll)
         if self.options.late_basin_of_vows:
             self._add_location_rule("HWL: Soul of the Dancer", lambda state: (
                 state.has("Small Lothric Banner", self.player)
@@ -560,6 +564,10 @@ class DarkSouls3World(World):
                     "Pyromancy Flame" not in randomized_items
                     or state.has("Pyromancy Flame", self.player)
                 )
+                # This isn't really necessary, but it ensures that the game logic knows players will
+                # want to do Lothric Castle after at least being _able_ to access Catacombs. This is
+                # useful for smooth item placement.
+                and self._has_any_scroll
             ))
 
             if self.options.late_basin_of_vows > 1: # After Small Doll

--- a/worlds/dark_souls_3/__init__.py
+++ b/worlds/dark_souls_3/__init__.py
@@ -487,11 +487,14 @@ class DarkSouls3World(World):
             self._add_entrance_rule("Dreg Heap", "PW2 -> DH")
             self._add_entrance_rule("Ringed City", "Small Envoy Banner")
 
-            if self.options.late_dlc:
-                self._add_entrance_rule(
-                    "Painted World of Ariandel (Before Contraption)",
-                    "Small Doll"
-                )
+            if self.options.late_dlc: # After Catacombs
+                self._add_entrance_rule("Painted World of Ariandel (Before Contraption)", self._has_any_scroll)
+
+            if self.options.late_dlc > 1: # After Small Doll
+                self._add_entrance_rule("Painted World of Ariandel (Before Contraption)", "Small Doll")
+            
+            if self.options.late_dlc > 2: # After Basin
+                self._add_entrance_rule("Painted World of Ariandel (Before Contraption)", "Basin of Vows")
 
         # Define the access rules to some specific locations
         if self._is_location_available("FS: Lift Chamber Key - Leonhard"):
@@ -925,12 +928,6 @@ class DarkSouls3World(World):
         self._add_location_rule("FK: Soul of the Blood of the Wolf", self._has_any_scroll)
         self._add_location_rule("FK: Cinders of a Lord - Abyss Watcher", self._has_any_scroll)
         self._add_entrance_rule("Catacombs of Carthus", self._has_any_scroll)
-        # Not really necessary but ensures players can decide which way to go
-        if self.options.enable_dlc:
-            self._add_entrance_rule(
-                "Painted World of Ariandel (After Contraption)",
-                self._has_any_scroll
-            )
 
 
     def _add_transposition_rules(self) -> None:


### PR DESCRIPTION
## What is this fixing or adding?

Adds further options for Late Basin of Vows so it can be after SLB or SLB and the Small Doll. This allows for more customizable access requirements for Lothric Castle.
Adds further options for Late DLC so it can be after Small Doll or Small Doll and Basin of Vows. This allows for more customizable access requirements for Painted World of Ariandel.

This was done in a way that the old toggle values map onto the new choice values using aliases for `true` and `false`.

## How was this tested?

Numerous generations and explicit checking that all options worked using plando alongside reading playthrough logs.