### PR TITLE
Removing modifying the itempool after fill

### DIFF
--- a/worlds/dark_souls_3/__init__.py
+++ b/worlds/dark_souls_3/__init__.py
@@ -376,6 +376,9 @@ class DarkSouls3World(World):
             num_required_extra_items -= 1
             itempool.append(self.create_item(item.name))
 
+        # Extra filler items for locations containing skip items
+        itempool.extend(self.create_filler() for _ in range(num_required_extra_items))
+
         # Removing items that will get placed during pre_fill
         # If Yhorm is at Iudex Gundyr, Storm Ruler must be randomized, so it can always be removed
         if self.yhorm_location.name == 'Iudex Gundyr':
@@ -386,9 +389,6 @@ class DarkSouls3World(World):
         # If the HWL Raw Gem is vanilla, it is early enough and doesn't need to be removed
         if self._is_location_available("HWL: Raw Gem - fort roof, lizard") and self.options.smooth_upgrade_items:
             itempool.remove(self.create_item("Raw Gem"))
-
-        # Extra filler items for locations containing skip items
-        itempool.extend(self.create_filler() for _ in range(num_required_extra_items))
 
         # Add items to itempool
         self.multiworld.itempool += itempool

--- a/worlds/dark_souls_3/__init__.py
+++ b/worlds/dark_souls_3/__init__.py
@@ -470,7 +470,14 @@ class DarkSouls3World(World):
 
         If the item could not be placed, it will be added to starting inventory.
         """
-        item = self.create_item(name)
+        item = next(
+            (
+                item for item in self.multiworld.itempool
+                if item.player == self.player and item.name == name
+            ),
+            None
+        )
+        if not item: return
 
         candidate_locations = [
             location for location in (

--- a/worlds/dark_souls_3/__init__.py
+++ b/worlds/dark_souls_3/__init__.py
@@ -383,7 +383,6 @@ class DarkSouls3World(World):
         # If the HWL Raw Gem is vanilla, it is early enough and doesn't need to be removed
         # If upgrade smoothing is enabled, make sure one raw gem is available early for SL1 players
         if self._is_location_available("HWL: Raw Gem - fort roof, lizard") and self.options.smooth_upgrade_items:
-        if self._is_location_available("HWL: Raw Gem - fort roof, lizard") and self.options.smooth_upgrade_items:
             self._fill_local_item("Raw Gem", [
                                   "Cemetery of Ash",
                                   "Firelink Shrine",

--- a/worlds/dark_souls_3/__init__.py
+++ b/worlds/dark_souls_3/__init__.py
@@ -1275,7 +1275,6 @@ class DarkSouls3World(World):
         passed, only locations meeting that condition will be considered.
 
         If the item could not be placed, it will be added to starting inventory.
-        A filler item will also be added to the itempool.
         """
         item = self.create_item(name)
 
@@ -1296,9 +1295,6 @@ class DarkSouls3World(World):
         if not candidate_locations:
             warning(f"Couldn't place \"{name}\" in a valid location for {self.multiworld.get_player_name(self.player)}. Adding it to starting inventory instead.")
             self.multiworld.push_precollected(self.create_item(name))
-
-            # If the item can't be placed, it was randomized, which means an item has to replace it.
-            self.multiworld.itempool.append(self.create_filler())
             return
 
         location = self.random.choice(candidate_locations)

--- a/worlds/dark_souls_3/__init__.py
+++ b/worlds/dark_souls_3/__init__.py
@@ -366,28 +366,7 @@ class DarkSouls3World(World):
         # Add items to itempool
         self.multiworld.itempool += itempool
 
-        # Remove certain items and place them early.
-        # If Yhorm is at Iudex Gundyr, Storm Ruler must be randomized, so it can always be removed
-        # Fill this manually so that, if very few slots are available in Cemetery of Ash, this
-        # doesn't get locked out by bad rolls on the next two fills.
-        if self.yhorm_location.name == 'Iudex Gundyr':
-            self._fill_local_item("Storm Ruler", ["Cemetery of Ash"],
-                                  lambda location: location.name != "CA: Coiled Sword - boss drop")
-
-        # If the Coiled Sword is vanilla, it is early enough and doesn't need to be removed
-        # Don't place this in the multiworld because it's necessary almost immediately, and don't
-        # mark it as a blocker for HWL because having a miniscule Sphere 1 screws with progression balancing.
-        if self._is_location_available("CA: Coiled Sword - boss drop"):
-            self._fill_local_item("Coiled Sword", ["Cemetery of Ash", "Firelink Shrine"])
-
-        # If the HWL Raw Gem is vanilla, it is early enough and doesn't need to be removed
-        # If upgrade smoothing is enabled, make sure one raw gem is available early for SL1 players
-        if self._is_location_available("HWL: Raw Gem - fort roof, lizard") and self.options.smooth_upgrade_items:
-            self._fill_local_item("Raw Gem", [
-                                  "Cemetery of Ash",
-                                  "Firelink Shrine",
-                                  "High Wall of Lothric"
-                                  ])
+        self._place_manual_items()
 
 
     def _create_injectable_items(self, num_required_extra_items: int) -> List[Item]:
@@ -474,6 +453,76 @@ class DarkSouls3World(World):
                 data = data.infuse(self.multiworld.random.choice(list(Infusion)))
 
         return DarkSouls3Item(self.player, data, classification=classification)
+
+
+    def _place_manual_items(self) -> None:
+        """Removes certain items from the item pool and manually places them in the local world.
+
+        We can't do this in pre_fill because the itempool may not be modified after create_items.
+        """
+        # If Yhorm is at Iudex Gundyr, Storm Ruler must be randomized, so it can always be moved.
+        # Fill this manually so that, if very few slots are available in Cemetery of Ash, this
+        # doesn't get locked out by bad rolls on the next two fills.
+        if self.yhorm_location.name == 'Iudex Gundyr':
+            self._fill_local_item("Storm Ruler", ["Cemetery of Ash"],
+                                  lambda location: location.name != "CA: Coiled Sword - boss drop")
+
+        # If the Coiled Sword is vanilla, it is early enough and doesn't need to be placed.
+        # Don't place this in the multiworld because it's necessary almost immediately, and don't
+        # mark it as a blocker for HWL because having a miniscule Sphere 1 screws with progression balancing.
+        if self._is_location_available("CA: Coiled Sword - boss drop"):
+            self._fill_local_item("Coiled Sword", ["Cemetery of Ash", "Firelink Shrine"])
+
+        # If the HWL Raw Gem is vanilla, it is early enough and doesn't need to be removed. If
+        # upgrade smoothing is enabled, make sure one raw gem is available early for SL1 players
+        if (
+            self._is_location_available("HWL: Raw Gem - fort roof, lizard")
+            and self.options.smooth_upgrade_items
+        ):
+            self._fill_local_item("Raw Gem", [
+                "Cemetery of Ash",
+                "Firelink Shrine",
+                "High Wall of Lothric"
+            ])
+
+
+    def _fill_local_item(
+        self, name: str,
+        regions: List[str],
+        additional_condition: Optional[Callable[[DarkSouls3Location], bool]] = None,
+    ) -> None:
+        """Chooses a valid location for the item with the given name and places it there.
+        
+        This always chooses a local location among the given regions. If additional_condition is
+        passed, only locations meeting that condition will be considered.
+
+        If the item could not be placed, it will be added to starting inventory.
+        """
+        item = self.create_item(name)
+
+        candidate_locations = [
+            location for location in (
+                self.multiworld.get_location(location.name, self.player)
+                for region in regions
+                for location in location_tables[region]
+                if self._is_location_available(location)
+                and not location.missable
+                and not location.conditional
+                and (not additional_condition or additional_condition(location))
+            )
+            if not location.item and location.progress_type != LocationProgressType.EXCLUDED
+            and location.item_rule(item)
+        ]
+
+        if not candidate_locations:
+            warning(f"Couldn't place \"{name}\" in a valid location for {self.multiworld.get_player_name(self.player)}. Adding it to starting inventory instead.")
+            self.multiworld.push_precollected(self.create_item(name))
+            return
+
+        location = self.random.choice(candidate_locations)
+        location.place_locked_item(item)
+        self.multiworld.itempool.remove(item)
+        
 
 
     def get_filler_item_name(self) -> str:
@@ -1263,43 +1312,6 @@ class DarkSouls3World(World):
                 f"Yhorm takes the place of {self.yhorm_location.name} in " +
                 f"{self.multiworld.get_player_name(self.player)}'s world\n")
 
-
-    def _fill_local_item(
-        self, name: str,
-        regions: List[str],
-        additional_condition: Optional[Callable[[DarkSouls3Location], bool]] = None,
-    ) -> None:
-        """Chooses a valid location for the item with the given name and places it there.
-        
-        This always chooses a local location among the given regions. If additional_condition is
-        passed, only locations meeting that condition will be considered.
-
-        If the item could not be placed, it will be added to starting inventory.
-        """
-        item = self.create_item(name)
-
-        candidate_locations = [
-            location for location in (
-                self.multiworld.get_location(location.name, self.player)
-                for region in regions
-                for location in location_tables[region]
-                if self._is_location_available(location)
-                and not location.missable
-                and not location.conditional
-                and (not additional_condition or additional_condition(location))
-            )
-            if not location.item and location.progress_type != LocationProgressType.EXCLUDED
-            and location.item_rule(item)
-        ]
-
-        if not candidate_locations:
-            warning(f"Couldn't place \"{name}\" in a valid location for {self.multiworld.get_player_name(self.player)}. Adding it to starting inventory instead.")
-            self.multiworld.push_precollected(self.create_item(name))
-            return
-
-        location = self.random.choice(candidate_locations)
-        location.place_locked_item(item)
-        self.multiworld.itempool.remove(item)
 
     def post_fill(self):
         """If item smoothing is enabled, rearrange items so they scale up smoothly through the run.

--- a/worlds/dark_souls_3/__init__.py
+++ b/worlds/dark_souls_3/__init__.py
@@ -328,7 +328,7 @@ class DarkSouls3World(World):
         # Add items to itempool
         self.multiworld.itempool += itempool
 
-        self._place_manual_items()
+        self._fill_local_items()
 
 
     def _create_injectable_items(self, num_required_extra_items: int) -> List[Item]:
@@ -427,7 +427,7 @@ class DarkSouls3World(World):
         return DarkSouls3Item(self.player, data, classification=classification)
 
 
-    def _place_manual_items(self) -> None:
+    def _fill_local_items(self) -> None:
         """Removes certain items from the item pool and manually places them in the local world.
 
         We can't do this in pre_fill because the itempool may not be modified after create_items.

--- a/worlds/dark_souls_3/__init__.py
+++ b/worlds/dark_souls_3/__init__.py
@@ -377,10 +377,13 @@ class DarkSouls3World(World):
             itempool.append(self.create_item(item.name))
 
         # Removing items that will get placed during pre_fill
+        # If Yhorm is at Iudex Gundyr, Storm Ruler must be randomized, so it can always be removed
         if self.yhorm_location.name == 'Iudex Gundyr':
             itempool.remove(self.create_item("Storm Ruler"))
+        # If the Coiled Sword is vanilla, it is early enough and doesn't need to be removed
         if self._is_location_available("CA: Coiled Sword - boss drop"):
             itempool.remove(self.create_item("Coiled Sword"))
+        # If the HWL Raw Gem is vanilla, it is early enough and doesn't need to be removed
         if self._is_location_available("HWL: Raw Gem - fort roof, lizard") and self.options.smooth_upgrade_items:
             itempool.remove(self.create_item("Raw Gem"))
 

--- a/worlds/dark_souls_3/__init__.py
+++ b/worlds/dark_souls_3/__init__.py
@@ -368,15 +368,15 @@ class DarkSouls3World(World):
 
         # Remove certain items and place them early.
         # If Yhorm is at Iudex Gundyr, Storm Ruler must be randomized, so it can always be removed
-        # Don't place this in the multiworld because it's necessary almost immediately, and don't
-        # mark it as a blocker for HWL because having a miniscule Sphere 1 screws with progression balancing.
+        # Fill this manually so that, if very few slots are available in Cemetery of Ash, this
+        # doesn't get locked out by bad rolls on the next two fills.
         if self.yhorm_location.name == 'Iudex Gundyr':
             self._fill_local_item("Storm Ruler", ["Cemetery of Ash"],
                                   lambda location: location.name != "CA: Coiled Sword - boss drop")
 
         # If the Coiled Sword is vanilla, it is early enough and doesn't need to be removed
-        # Fill this manually so that, if very few slots are available in Cemetery of Ash, this
-        # doesn't get locked out by bad rolls on the next two fills.
+        # Don't place this in the multiworld because it's necessary almost immediately, and don't
+        # mark it as a blocker for HWL because having a miniscule Sphere 1 screws with progression balancing.
         if self._is_location_available("CA: Coiled Sword - boss drop"):
             self._fill_local_item("Coiled Sword", ["Cemetery of Ash", "Firelink Shrine"])
 


### PR DESCRIPTION
## What is this fixing or adding?

1. Adds an `all_excluded_locations` set to track a player's `exclude_locations` so they can be used in `_is_location_available` instead of getting erased during `create_region`
2. Changes Storm Ruler, Coiled Sword, and Raw Gem to get removed from the pool when necessary and placed during `create_items` instead.
3. Modified `_fill_local_item` so instead of unplaceable `mandatory` items throwing an error, everything is now effectively "mandatory" and failing to place an item throws it into starting inventory instead.

## How was this tested?

Multiple generations, reading playthroughs, testing through plando and by forcing Yhorm to be at Iudex Gundyr.