### PR TITLE
Adding Removed options to error

### DIFF
--- a/worlds/dark_souls_3/Options.py
+++ b/worlds/dark_souls_3/Options.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 import json
 import typing
 
-from Options import Choice, DeathLink, DefaultOnToggle, ExcludeLocations, ItemDict, NamedRange, Option, PerGameCommonOptions, Range, Toggle, VerifyKeys
+from Options import Choice, DeathLink, DefaultOnToggle, ExcludeLocations, ItemDict, NamedRange, Option, PerGameCommonOptions, Range, Removed, Toggle, VerifyKeys
 
 
 class ExcludedLocationsOption(Choice):
@@ -391,3 +391,17 @@ class DarkSouls3Options(PerGameCommonOptions):
     all_chests_are_mimics: AllChestsAreMimicsOption
     impatient_mimics: ImpatientMimicsOption
     exclude_locations: DS3ExcludeLocations
+
+    # Removed
+    pool_type: Removed
+    enable_weapon_locations: Removed
+    enable_shield_locations: Removed
+    enable_armor_locations: Removed
+    enable_ring_locations: Removed
+    enable_spell_locations: Removed
+    enable_key_locations: Removed
+    enable_boss_locations: Removed
+    enable_npc_locations: Removed
+    enable_misc_locations: Removed
+    enable_health_upgrade_locations: Removed
+    enable_progressive_locations: Removed

--- a/worlds/dark_souls_3/Options.py
+++ b/worlds/dark_souls_3/Options.py
@@ -348,7 +348,7 @@ class ImpatientMimicsOption(Toggle):
 
 
 class DS3ExcludeLocations(ExcludeLocations):
-    """Prevent these locations from having an important item"""
+    """Forces these locations to have certain types of items, exact behavior depends on the "Excluded Locations" option."""
     default = {"Hidden", "Small Crystal Lizards", "Upgrade", "Small Souls", "Miscellaneous"}
 
 

--- a/worlds/dark_souls_3/__init__.py
+++ b/worlds/dark_souls_3/__init__.py
@@ -111,11 +111,6 @@ class DarkSouls3World(World):
             self.yhorm_location = default_yhorm_location
 
 
-    def _exclude_location_group(self, name: str):
-        """Adds all the locations in the given location group to the set of excluded locations."""
-        self.options.exclude_locations.value.update(location_name_groups[name])
-
-
     def _allow_boss_for_yhorm(self, boss: DS3BossInfo) -> bool:
         """Returns whether boss is a valid location for Yhorm in this seed."""
 


### PR DESCRIPTION
## What is this fixing or adding?

Old options still being used will throw errors.

Also changed the Exclude Location docstring to match the fact that what exactly it does depends on the Excluded Locations option. 

Also removed `_exclude_location_group` since it was no longer used

## How was this tested?

Generations
