### PR TITLE
Changes for WebHost options display and the options overhaul

### DIFF
--- a/worlds/dark_souls_3/Options.py
+++ b/worlds/dark_souls_3/Options.py
@@ -3,24 +3,22 @@ from dataclasses import dataclass
 import json
 import typing
 
-from Options import Choice, DeathLink, DefaultOnToggle, ExcludeLocations, ItemDict, NamedRange, Option, PerGameCommonOptions, Range, Removed, Toggle, VerifyKeys
+from Options import Choice, DeathLink, DefaultOnToggle, ExcludeLocations, ItemDict, NamedRange, Option, OptionGroup, \
+    PerGameCommonOptions, Range, Removed, Toggle, VerifyKeys
 
 
 class ExcludedLocationsOption(Choice):
-    """Which items can be placed in excluded locations in DS3.
-
-    * Unnecessary: Excluded locations can't have progression items, but they can
-      have useful items.
-    * Unimportant: Neither progression items nor useful items can be placed in
-      excluded locations.
-    * Unrandomized: Excluded locations always contain the same item as in
-      vanilla Dark Souls III.
-
-    A "progression item" is anything that's required to unlock another location
-    in some game. A "useful item" is something each game defines individually,
-    usually items that are quite desirable but not strictly necessary.
     """
-    display_name = "Excluded Locations"
+    Which items can be placed in excluded locations in DS3.
+
+    - Unnecessary: Excluded locations can't have progression items, but they can have useful items.
+    - Unimportant: Neither progression items nor useful items can be placed in excluded locations.
+    - Unrandomized: Excluded locations always contain the same item as in vanilla Dark Souls III.
+
+    A "progression item" is anything that's required to unlock another location in some game.
+    A "useful item" is something each game defines individually, usually items that are quite desirable but not strictly necessary.
+    """
+    display_name = "Excluded Locations Behavior"
     option_unnecessary = 1
     option_unimportant = 2
     option_unrandomized = 3
@@ -28,103 +26,120 @@ class ExcludedLocationsOption(Choice):
 
 
 class MissableLocationsOption(Choice):
-    """Which items can be placed in locations that can be permanently missed.
-
-    * Unnecessary: Missable locations can't have progression items, but they can
-      have useful items.
-    * Unimportant: Neither progression items nor useful items can be placed in
-      missable locations.
-    * Unrandomized: Missable locations always contain the same item as in
-      vanilla Dark Souls III.
-
-    A "progression item" is anything that's required to unlock another location
-    in some game. A "useful item" is something each game defines individually,
-    usually items that are quite desirable but not strictly necessary.
     """
-    display_name = "Missable Locations"
+    Which items can be placed in locations that can be permanently missed.
+
+    - Unnecessary: Missable locations can't have progression items, but they can have useful items.
+    - Unimportant: Neither progression items nor useful items can be placed in missable locations.
+    - Unrandomized: Missable locations always contain the same item as in vanilla Dark Souls III.
+
+    A "progression item" is anything that's required to unlock another location in some game.
+    A "useful item" is something each game defines individually, usually items that are quite desirable but not strictly necessary.
+    """
+    display_name = "Missable Locations Behavior"
     option_unnecessary = 1
     option_unimportant = 2
     option_unrandomized = 3
     default = 2
 
-    
-class SmoothSoulItemsOption(DefaultOnToggle):
-    """Whether to distribute soul items in a similar order as the base game.
 
-    By default, soul items will be distributed totally randomly. If this is set,
-    less valuable soul items will generally appear in earlier spheres and more
-    valuable ones will generally appear later.
+class SmoothSoulItemsOption(DefaultOnToggle):
+    """
+    Whether to distribute soul items in a similar order as the base game.
+
+    By default, soul items will be distributed totally randomly.
+    If this is set, less valuable soul items will generally appear in earlier spheres and more valuable ones will generally appear later.
     """
     display_name = "Smooth Soul Items"
 
 
 class SmoothUpgradeItemsOption(DefaultOnToggle):
-    """Whether to distribute upgrade items in a similar order as the base game.
+    """
+    Whether to distribute upgrade items in a similar order as the base game.
 
-    By default, upgrade items will be distributed totally randomly. If this is
-    set, lower-level upgrade items will generally appear in earlier spheres and
-    higher-level ones will generally appear later.
+    By default, upgrade items will be distributed totally randomly.
+    If this is set, lower-level upgrade items will generally appear in earlier spheres and higher-level ones will generally appear later.
     """
     display_name = "Smooth Upgrade Items"
 
 
 class SmoothUpgradedWeaponsOption(DefaultOnToggle):
-    """Whether to distribute upgraded weapons in a similar order as the base game.
+    """
+    Whether to distribute upgraded weapons in a similar order as the base game.
 
-    By default, upgraded weapons will be distributed totally randomly. If this
-    is set, lower-level weapons will generally appear in earlier spheres and
-    higher-level ones will generally appear later.
+    By default, upgraded weapons will be distributed totally randomly.
+    If this is set, lower-level weapons will generally appear in earlier spheres and higher-level ones will generally appear later.
     """
     display_name = "Smooth Upgraded Weapons"
 
 
 class RandomizeStartingLoadout(DefaultOnToggle):
-    """Randomizes the equipment characters begin with."""
+    """
+    Randomizes the equipment characters begin with.
+    """
     display_name = "Randomize Starting Loadout"
 
 
 class RequireOneHandedStartingWeapons(DefaultOnToggle):
-    """Require starting equipment to be usable one-handed."""
+    """
+    Require starting equipment to be usable one-handed.
+    """
     display_name = "Require One-Handed Starting Weapons"
 
 
 class GuaranteedItemsOption(ItemDict):
-    """Guarantees that the specified items will be in the item pool"""
+    """
+    Guarantees that the specified items will be in the item pool.
+    """
     display_name = "Guaranteed Items"
 
 
 class AutoEquipOption(Toggle):
-    """Automatically equips any received armor or left/right weapons."""
+    """
+    Automatically equips any received armor or left/right weapons.
+    """
     display_name = "Auto-Equip"
 
 
 class LockEquipOption(Toggle):
-    """Lock the equipment slots so you cannot change your armor or your left/right weapons. Works great with the Auto-equip option."""
+    """
+    Lock the equipment slots so you cannot change your armor or your left/right weapons. Works great with the Auto-equip option.
+    """
     display_name = "Lock Equipment Slots"
 
 
 class NoWeaponRequirementsOption(Toggle):
-    """Disable the weapon requirements by removing any movement or damage penalties, permitting you to use any weapon early."""
+    """
+    Disable the weapon requirements by removing any movement or damage penalties, permitting you to use any weapon early.
+    """
     display_name = "No Weapon Requirements"
 
 
 class NoSpellRequirementsOption(Toggle):
-    """Disable the spell requirements permitting you to use any spell"""
+    """
+    Disable the spell requirements permitting you to use any spell.
+    """
     display_name = "No Spell Requirements"
 
 
 class NoEquipLoadOption(Toggle):
-    """Disable the equip load constraint from the game"""
+    """
+    Disable the equip load constraint from the game.
+    """
     display_name = "No Equip Load"
 
 
 class RandomizeInfusionOption(Toggle):
-    """Enable this option to infuse a percentage of the pool of weapons and shields."""
+    """
+    Enable this option to infuse a percentage of the pool of weapons and shields.
+    """
     display_name = "Randomize Infusion"
 
 
 class RandomizeInfusionPercentageOption(NamedRange):
-    """The percentage of weapons/shields in the pool to be infused if Randomize Infusion is toggled"""
+    """
+    The percentage of weapons/shields in the pool to be infused if Randomize Infusion is toggled.
+    """
     display_name = "Percentage of Infused Weapons"
     range_start = 0
     range_end = 100
@@ -134,12 +149,12 @@ class RandomizeInfusionPercentageOption(NamedRange):
 
 
 class RandomizeWeaponLevelOption(Choice):
-    """Enable this option to upgrade a percentage of the pool of weapons to a
-    random value between the minimum and maximum levels defined.
+    """
+    Enable this option to upgrade a percentage of the pool of weapons to a random value between the minimum and maximum levels defined.
 
-    All: All weapons are eligible, both basic and epic
-    Basic: Only weapons that can be upgraded to +10
-    Epic: Only weapons that can be upgraded to +5
+    - All: All weapons are eligible, both basic and epic
+    - Basic: Only weapons that can be upgraded to +10
+    - Epic: Only weapons that can be upgraded to +5
     """
     display_name = "Randomize Weapon Level"
     option_none = 0
@@ -149,7 +164,9 @@ class RandomizeWeaponLevelOption(Choice):
 
 
 class RandomizeWeaponLevelPercentageOption(Range):
-    """The percentage of weapons in the pool to be upgraded if randomize weapons level is toggled"""
+    """
+    The percentage of weapons in the pool to be upgraded if randomize weapons level is toggled.
+    """
     display_name = "Percentage of Randomized Weapons"
     range_start = 0
     range_end = 100
@@ -157,7 +174,9 @@ class RandomizeWeaponLevelPercentageOption(Range):
 
 
 class MinLevelsIn5WeaponPoolOption(Range):
-    """The minimum upgraded value of a weapon in the pool of weapons that can only reach +5"""
+    """
+    The minimum upgraded value of a weapon in the pool of weapons that can only reach +5.
+    """
     display_name = "Minimum Level of +5 Weapons"
     range_start = 0
     range_end = 5
@@ -165,7 +184,9 @@ class MinLevelsIn5WeaponPoolOption(Range):
 
 
 class MaxLevelsIn5WeaponPoolOption(Range):
-    """The maximum upgraded value of a weapon in the pool of weapons that can only reach +5"""
+    """
+    The maximum upgraded value of a weapon in the pool of weapons that can only reach +5.
+    """
     display_name = "Maximum Level of +5 Weapons"
     range_start = 0
     range_end = 5
@@ -173,7 +194,9 @@ class MaxLevelsIn5WeaponPoolOption(Range):
 
 
 class MinLevelsIn10WeaponPoolOption(Range):
-    """The minimum upgraded value of a weapon in the pool of weapons that can reach +10"""
+    """
+    The minimum upgraded value of a weapon in the pool of weapons that can reach +10.
+    """
     display_name = "Minimum Level of +10 Weapons"
     range_start = 0
     range_end = 10
@@ -181,7 +204,9 @@ class MinLevelsIn10WeaponPoolOption(Range):
 
 
 class MaxLevelsIn10WeaponPoolOption(Range):
-    """The maximum upgraded value of a weapon in the pool of weapons that can reach +10"""
+    """
+    The maximum upgraded value of a weapon in the pool of weapons that can reach +10.
+    """
     display_name = "Maximum Level of +10 Weapons"
     range_start = 0
     range_end = 10
@@ -189,8 +214,9 @@ class MaxLevelsIn10WeaponPoolOption(Range):
 
 
 class EarlySmallLothricBanner(Choice):
-    """This option makes it so the user can choose to force the Small Lothric Banner into an early sphere in their world
-     or into an early sphere across all worlds."""
+    """
+    This option makes it so the user can choose to force the Small Lothric Banner into an early sphere in their world or into an early sphere across all worlds.
+    """
     display_name = "Early Small Lothric Banner"
     option_off = 0
     option_early_global = 1
@@ -199,10 +225,13 @@ class EarlySmallLothricBanner(Choice):
 
 
 class LateBasinOfVowsOption(Choice):
-    """This option makes it so the Basin of Vows is still randomized, but you can choose the requirements to venture into Lothric Castle.
-    "Off": You may have to enter Lothric Castle and the areas beyond it before finding your Small Lothric Banner.
-    "After Small Lothric Banner": You are guaranteed to find your Small Lothric Banner before needing to enter Lothric Castle.
-    "After Small Doll": You are guaranteed to find your Small Lothric Banner and your Small Doll before needing to enter Lothric Castle."""
+    """
+    This option makes it so the Basin of Vows is still randomized, but you can choose the requirements to venture into Lothric Castle.
+
+    - Off: You may have to enter Lothric Castle and the areas beyond it before finding your Small Lothric Banner.
+    - After Small Lothric Banner: You are guaranteed to find your Small Lothric Banner before needing to enter Lothric Castle.
+    - After Small Doll: You are guaranteed to find your Small Lothric Banner and your Small Doll before needing to enter Lothric Castle.
+    """
     display_name = "Late Basin of Vows"
     option_off = 0
     alias_false = 0
@@ -212,10 +241,13 @@ class LateBasinOfVowsOption(Choice):
 
 
 class LateDLCOption(Choice):
-    """This option makes it so the Small Doll is still randomized, but you can choose the requirements to venture into Painted World of Ariandel.
-    "Off": You may have to enter Ariandel and the areas beyond it before finding your Small Doll.
-    "After Small Doll": You are guaranteed to find your Small Doll before needing to enter Ariandel.
-    "After Basin": You are guaranteed to find your Small Doll and your Basin of Vows before needing to enter Ariandel."""
+    """
+    This option makes it so the Small Doll is still randomized, but you can choose the requirements to venture into Painted World of Ariandel.
+
+    - Off: You may have to enter Ariandel and the areas beyond it before finding your Small Doll.
+    - After Small Doll: You are guaranteed to find your Small Doll before needing to enter Ariandel.
+    - After Basin: You are guaranteed to find your Small Doll and your Basin of Vows before needing to enter Ariandel.
+    """
     display_name = "Late DLC"
     option_off = 0
     alias_false = 0
@@ -225,27 +257,32 @@ class LateDLCOption(Choice):
 
 
 class EnableDLCOption(Toggle):
-    """To use this option, you must own both the ASHES OF ARIANDEL and the RINGED CITY DLC"""
+    """
+    To use this option, you must own both the ASHES OF ARIANDEL and the RINGED CITY DLC.
+    """
     display_name = "Enable DLC"
 
 
 class EnableNGPOption(Toggle):
-    """Whether to include items and locations exclusive to NG+ cycles"""
+    """
+    Whether to include items and locations exclusive to NG+ cycles.
+    """
     display_name = "Enable NG+"
 
 
 class RandomizeEnemiesOption(DefaultOnToggle):
-    """Whether to randomize enemy and boss placements.
+    """
+    Whether to randomize enemy and boss placements.
 
-    If this is enabled, the Storm Ruler sword is granted immediately upon meeting Yhorm the Giant
-    instead of being randomized into the world.
+    If this is enabled, the Storm Ruler sword is granted immediately upon meeting Yhorm the Giant instead of being randomized into the world.
     """
     display_name = "Randomize Enemies"
 
 
 class RandomEnemyPresetOption(Option[typing.Dict[str, typing.Any]], VerifyKeys):
-    """The YAML preset for the static enemy randomizer.
-    
+    """
+    The YAML preset for the static enemy randomizer.
+
     See the static randomizer documentation in randomizer\\presets\\README.txt for details.
     """
     display_name = "Random Enemy Preset"
@@ -272,11 +309,11 @@ class RandomEnemyPresetOption(Option[typing.Dict[str, typing.Any]], VerifyKeys):
 
 
 class RandomizeMimicsWithEnemiesOption(Toggle):
-    """Whether to mix Mimics into the main enemy pool.
+    """
+    Whether to mix Mimics into the main enemy pool.
 
-    If this is enabled, Mimics will be replaced by normal enemies who drop the Mimic rewards on
-    death, and Mimics will be placed randomly in place of normal enemies. It's recommended to
-    enable Impatient Mimics as well if you enable this.
+    If this is enabled, Mimics will be replaced by normal enemies who drop the Mimic rewards on death, and Mimics will be placed randomly in place of normal enemies.
+    It's recommended to enable Impatient Mimics as well if you enable this.
 
     This is ignored unless enemies are randomized.
     """
@@ -284,11 +321,11 @@ class RandomizeMimicsWithEnemiesOption(Toggle):
 
 
 class RandomizeSmallCrystalLizardsWithEnemiesOption(Toggle):
-    """Whether to mix small Crystal Lizards into the main enemy pool.
+    """
+    Whether to mix small Crystal Lizards into the main enemy pool.
 
-    If this is enabled, Crystal Lizards will be replaced by normal enemies who drop the Crystal
-    Lizard rewards on death, and Crystal Lizards will be placed randomly in place of normal
-    enemies.
+    If this is enabled, Crystal Lizards will be replaced by normal enemies who drop the Crystal Lizard rewards on death,
+    and Crystal Lizards will be placed randomly in place of normal enemies.
 
     This is ignored unless enemies are randomized.
     """
@@ -296,7 +333,8 @@ class RandomizeSmallCrystalLizardsWithEnemiesOption(Toggle):
 
 
 class ReduceHarmlessEnemiesOption(Toggle):
-    """Whether to reduce the frequency that "harmless" enemies appear.
+    """
+    Whether to reduce the frequency that "harmless" enemies appear.
 
     Enable this to add a bit of extra challenge. This severely limits the number of enemies that
     are slow to aggro, slow to attack, and do very little damage that appear in the enemy pool.
@@ -307,10 +345,11 @@ class ReduceHarmlessEnemiesOption(Toggle):
 
 
 class SimpleEarlyBossesOption(DefaultOnToggle):
-    """Whether to avoid replacing Iudex Gundyr and Vordt with late bosses.
+    """
+    Whether to avoid replacing Iudex Gundyr and Vordt with late bosses.
 
-    This excludes all bosses after Dancer of the Boreal Valley from these two boss fights. Disable
-    it for a chance at a much harder early game.
+    This excludes all bosses after Dancer of the Boreal Valley from these two boss fights.
+    Disable it for a chance at a much harder early game.
 
     This is ignored unless enemies are randomized.
     """
@@ -318,10 +357,10 @@ class SimpleEarlyBossesOption(DefaultOnToggle):
 
 
 class ScaleEnemiesOption(DefaultOnToggle):
-    """Whether to scale randomized enemy stats to match the areas in which they appear.
+    """
+    Whether to scale randomized enemy stats to match the areas in which they appear.
 
-    Disabling this will tend to make the early game much more difficult and the late game much
-    easier.
+    Disabling this will tend to make the early game much more difficult and the late game much easier.
 
     This is ignored unless enemies are randomized.
     """
@@ -329,10 +368,10 @@ class ScaleEnemiesOption(DefaultOnToggle):
 
 
 class AllChestsAreMimicsOption(Toggle):
-    """Whether to replace all chests with mimics that drop the same items.
+    """
+    Whether to replace all chests with mimics that drop the same items.
 
-    If "Randomize Mimics With Enemies" is set, these chests will instead be replaced with random
-    enemies that drop the same items.
+    If "Randomize Mimics With Enemies" is set, these chests will instead be replaced with random enemies that drop the same items.
 
     This is ignored unless enemies are randomized.
     """
@@ -340,7 +379,8 @@ class AllChestsAreMimicsOption(Toggle):
 
 
 class ImpatientMimicsOption(Toggle):
-    """Whether mimics should attack as soon as you get close.
+    """
+    Whether mimics should attack as soon as you get close.
 
     This is ignored unless enemies are randomized.
     """
@@ -348,7 +388,9 @@ class ImpatientMimicsOption(Toggle):
 
 
 class DS3ExcludeLocations(ExcludeLocations):
-    """Forces these locations to have certain types of items, exact behavior depends on the "Excluded Locations" option."""
+    """
+    Forces these locations to have certain types of items, exact behavior depends on the "Excluded Locations Behavior" option.
+    """
     default = {"Hidden", "Small Crystal Lizards", "Upgrade", "Small Souls", "Miscellaneous"}
 
 
@@ -405,3 +447,48 @@ class DarkSouls3Options(PerGameCommonOptions):
     enable_misc_locations: Removed
     enable_health_upgrade_locations: Removed
     enable_progressive_locations: Removed
+
+
+option_groups = [
+    OptionGroup("Equipment Options", [
+        RandomizeStartingLoadout,
+        RequireOneHandedStartingWeapons,
+        AutoEquipOption,
+        LockEquipOption,
+        NoEquipLoadOption,
+        NoWeaponRequirementsOption,
+        NoSpellRequirementsOption,
+    ]),
+    OptionGroup("Item Smoothing Options", [
+        SmoothSoulItemsOption,
+        SmoothUpgradeItemsOption,
+        SmoothUpgradedWeaponsOption,
+    ]),
+    OptionGroup("Weapon Infusion and Level Options", [
+        RandomizeInfusionOption,
+        RandomizeInfusionPercentageOption,
+        RandomizeWeaponLevelOption,
+        RandomizeWeaponLevelPercentageOption,
+        MinLevelsIn5WeaponPoolOption,
+        MaxLevelsIn5WeaponPoolOption,
+        MinLevelsIn10WeaponPoolOption,
+        MaxLevelsIn10WeaponPoolOption,
+    ]),
+    OptionGroup("Enemy Randomizer Options", [
+        RandomizeEnemiesOption,
+        RandomEnemyPresetOption,
+        SimpleEarlyBossesOption,
+        ScaleEnemiesOption,
+        RandomizeMimicsWithEnemiesOption,
+        RandomizeSmallCrystalLizardsWithEnemiesOption,
+        ReduceHarmlessEnemiesOption,
+        AllChestsAreMimicsOption,
+        ImpatientMimicsOption,
+    ]),
+    OptionGroup("Item & Location Behavior Options", [
+        ExcludedLocationsOption,
+        DS3ExcludeLocations,
+        MissableLocationsOption,
+        GuaranteedItemsOption,
+    ])
+]

--- a/worlds/dark_souls_3/__init__.py
+++ b/worlds/dark_souls_3/__init__.py
@@ -13,7 +13,7 @@ from worlds.generic.Rules import CollectionRule, ItemRule, add_rule, add_item_ru
 from .Bosses import DS3BossInfo, all_bosses, default_yhorm_location
 from .Items import DarkSouls3Item, DS3ItemCategory, DS3ItemData, Infusion, UsefulIf, filler_item_names, item_descriptions, item_dictionary, item_name_groups
 from .Locations import DarkSouls3Location, DS3LocationData, location_tables, location_descriptions, location_dictionary, location_name_groups, region_order
-from .Options import DarkSouls3Options, EarlySmallLothricBanner
+from .Options import DarkSouls3Options, EarlySmallLothricBanner, option_groups
 
 
 class DarkSouls3Web(WebWorld):
@@ -38,7 +38,7 @@ class DarkSouls3Web(WebWorld):
     )
 
     tutorials = [setup_en, setup_fr]
-
+    option_groups = option_groups
     item_descriptions = item_descriptions
 
 
@@ -63,8 +63,8 @@ class DarkSouls3World(World):
     }
     location_name_groups = location_name_groups
     item_name_groups = item_name_groups
-    location_descriptions = location_descriptions
-    item_descriptions = item_descriptions
+    # location_descriptions = location_descriptions
+    # item_descriptions = item_descriptions
 
     yhorm_location: Optional[DS3BossInfo]
     """If enemy randomization is enabled, this is the boss who Yhorm the Giant should replace.


### PR DESCRIPTION
## What is this fixing or adding?

The options overhaul significantly changes how options and their tooltips displayed on WebHost. This fixes the various formatting oddities this would cause and also adds option groups. (If you have a better name for "Item and Location Behavior Options" please tell me).

This also comments out the item and location description code because those were removed in the options/WebHost overhaul.

## How was this tested?

Looking at WebHost and generating the template yaml and some games.

## If this makes graphical changes, please attach screenshots.

![Screenshot 2024-06-10 094843](https://github.com/nex3/Archipelago/assets/60412657/7373a45b-48fa-498c-99ab-46c18b7e522d)
