### PR TITLE
Missable Titanite Lizards and excluded locations

### DIFF
--- a/worlds/dark_souls_3/Locations.py
+++ b/worlds/dark_souls_3/Locations.py
@@ -2062,9 +2062,9 @@ location_tables = {
         DS3LocationData("LC: Irithyll Rapier - basement, miniboss drop", "Irithyll Rapier",
                         miniboss=True),  # Boreal Outrider drop
         DS3LocationData("LC: Twinkling Titanite - dark room mid, out door opposite wyvern, lizard",
-                        "Twinkling Titanite x2", lizard=True),
+                        "Twinkling Titanite x2", lizard=True, missable=True),
         DS3LocationData("LC: Twinkling Titanite - moat, right path, lizard",
-                        "Twinkling Titanite x2", lizard=True),
+                        "Twinkling Titanite x2", lizard=True, missable=True),
         DS3LocationData("LC: Gotthard Twinswords - by Grand Archives door, after PC and AL bosses",
                         "Gotthard Twinswords", conditional=True),
         DS3LocationData("LC: Grand Archives Key - by Grand Archives door, after PC and AL bosses",

--- a/worlds/dark_souls_3/__init__.py
+++ b/worlds/dark_souls_3/__init__.py
@@ -146,7 +146,7 @@ class DarkSouls3World(World):
         # allow Yhorm as Iudex Gundyr if there's at least one available location.
         return any(
             self._is_location_available(location)
-            and location.name not in self.options.exclude_locations.value
+            and location.name not in self.all_excluded_locations
             and location.name != "CA: Coiled Sword - boss drop"
             for location in location_tables["Cemetery of Ash"]
         )
@@ -1211,7 +1211,7 @@ class DarkSouls3World(World):
         """
 
         unnecessary_locations = (
-            self.options.exclude_locations.value
+            self.all_excluded_locations
             if self.options.excluded_locations == "unnecessary"
             else set()
         ).union(

--- a/worlds/dark_souls_3/__init__.py
+++ b/worlds/dark_souls_3/__init__.py
@@ -146,7 +146,7 @@ class DarkSouls3World(World):
         # allow Yhorm as Iudex Gundyr if there's at least one available location.
         return any(
             self._is_location_available(location)
-            and location.name not in self.all_excluded_locations
+            and location.name not in self.options.exclude_locations.value
             and location.name != "CA: Coiled Sword - boss drop"
             for location in location_tables["Cemetery of Ash"]
         )
@@ -1211,7 +1211,7 @@ class DarkSouls3World(World):
         """
 
         unnecessary_locations = (
-            self.all_excluded_locations
+            self.options.exclude_locations.value
             if self.options.excluded_locations == "unnecessary"
             else set()
         ).union(


### PR DESCRIPTION
## What is this fixing or adding?

Two Titanite Lizards are missable as defeating one and then leaving the area or dying causes the other to never spawn. This changes them to missable.

## How was this tested?

Generations with progression items plando'ed onto the Twinkling Titanite which prompt "Can't place item [...] due to fill condition not met." after these changes.
