### PR TITLE
Add indirect condition for Anor Londo

### DIFF
--- a/worlds/dark_souls_3/__init__.py
+++ b/worlds/dark_souls_3/__init__.py
@@ -978,6 +978,11 @@ class DarkSouls3World(World):
             self._can_get(state, "US: Soul of the Rotted Greatwood")
             and state.has("Dreamchaser's Ashes", self.player)
         ))
+        # Add indirect condition since reaching AL requires deafeating Pontiff which requires defeating Greatwood in US
+        self.multiworld.register_indirect_condition(
+            self.get_region("Undead Settlement"),
+            self.get_entrance("Go To Anor Londo")
+        )
 
         # Kill Creighton and Aldrich to trigger this opportunity for invasion
         self._add_location_rule([


### PR DESCRIPTION
## What is this fixing or adding?

AL access requires defeating Pontiff (this is fine, because the AL access entrance and Pontiff are in the same region) but defeating Pontiff requires defeating the Rotted Greatwood, which is all the way over in the different region of US. Currently, this doesn't matter, since US is always accessible before / at the same time as AL and, for the "at the same time" case, is _before_ AL in the region sweep. However, in the future it could matter, for example, if we added regions for the various Yhorm-locked location sets, as that region could become accessible _after_ IBV.

This is mostly just to make the indirect condition checker happy and a very small amount of future-proofing for something like fog-gate rando.

## How was this tested?

A generation with the [indirect condition checker](https://github.com/NewSoupVi/Archipelago/tree/indirect_condition_checker) no longer throwing an error.