### PR TITLE
Fixing determinism and making smooth faster

### DIFF
--- a/worlds/dark_souls_3/__init__.py
+++ b/worlds/dark_souls_3/__init__.py
@@ -1375,7 +1375,8 @@ class DarkSouls3World(World):
         region order, and then the best items in a sphere go into the multiworld.
         """
 
-        locations_by_sphere = [sorted(loc for loc in sphere if loc.item.player == self.player and not loc.locked) for sphere in self.multiworld.get_spheres()]
+        locations_by_sphere = [sorted(loc for loc in sphere if loc.item.player == self.player and not loc.locked)
+                               for sphere in self.multiworld.get_spheres()]
 
         # All items in the base game in approximately the order they appear
         all_item_order = [

--- a/worlds/dark_souls_3/__init__.py
+++ b/worlds/dark_souls_3/__init__.py
@@ -1375,7 +1375,7 @@ class DarkSouls3World(World):
         region order, and then the best items in a sphere go into the multiworld.
         """
 
-        locations_by_sphere = list(self.multiworld.get_spheres())
+        locations_by_sphere = [sorted(loc for loc in sphere if loc.item.player == self.player and not loc.locked) for sphere in self.multiworld.get_spheres()]
 
         # All items in the base game in approximately the order they appear
         all_item_order = [
@@ -1421,9 +1421,7 @@ class DarkSouls3World(World):
                 loc
                 for locations in locations_by_sphere
                 for loc in locations
-                if loc.item.player == self.player
-                and not loc.locked
-                and loc.item.name in names
+                if loc.item.name in names
             ]
 
             # It's expected that there may be more total items than there are matching locations if
@@ -1435,13 +1433,8 @@ class DarkSouls3World(World):
                     f"contain smoothed items, but only {len(item_order)} items to smooth."
                 )
 
-            for i, all_locations in enumerate(locations_by_sphere):
-                locations = [
-                    loc for loc in all_locations
-                    if loc.item.player == self.player
-                    and not loc.locked
-                    and loc.item.name in names
-                ]
+            for all_locations in locations_by_sphere:
+                locations = [loc for loc in all_locations if loc.item.name in names]
 
                 # Check the game, not the player, because we know how to sort within regions for DS3
                 offworld = self._shuffle([loc for loc in locations if loc.game != "Dark Souls III"])

--- a/worlds/dark_souls_3/__init__.py
+++ b/worlds/dark_souls_3/__init__.py
@@ -1419,8 +1419,8 @@ class DarkSouls3World(World):
 
             all_matching_locations = [
                 loc
-                for locations in locations_by_sphere
-                for loc in locations
+                for sphere in locations_by_sphere
+                for loc in sphere
                 if loc.item.name in names
             ]
 
@@ -1433,8 +1433,8 @@ class DarkSouls3World(World):
                     f"contain smoothed items, but only {len(item_order)} items to smooth."
                 )
 
-            for all_locations in locations_by_sphere:
-                locations = [loc for loc in all_locations if loc.item.name in names]
+            for sphere in locations_by_sphere:
+                locations = [loc for loc in sphere if loc.item.name in names]
 
                 # Check the game, not the player, because we know how to sort within regions for DS3
                 offworld = self._shuffle([loc for loc in locations if loc.game != "Dark Souls III"])

--- a/worlds/dark_souls_3/__init__.py
+++ b/worlds/dark_souls_3/__init__.py
@@ -1484,13 +1484,8 @@ class DarkSouls3World(World):
         items: List[Union[DS3ItemData, DarkSouls3Item]]
     ) -> Union[DS3ItemData, DarkSouls3Item]:
         """Returns the next item in items that can be assigned to location."""
-        # Non-excluded locations can take any item we throw at them. (More specifically, if they can
-        # take one item in a group, they can take any other).
-        if location.progress_type != LocationProgressType.EXCLUDED: return items.pop(0)
-
-        # Excluded locations require filler items.
         for i, item in enumerate(items):
-            if item.classification == ItemClassification.filler:
+            if location.can_fill(self.multiworld.state, item, False):
                 return items.pop(i)
 
         # If we can't find a suitable item, give up and assign an unsuitable one.


### PR DESCRIPTION
## What is this fixing or adding?

There was a non-determinism issue because `get_sphere()` uses sets, which were then iterated over in a random order. This instead turns the spheres into lists and also does some of the filtering at the same time. Also changes the way smoothing checks for place-ability of an item, instead of just checking excluded, it uses `can_fill` which can cover a few really weird edge cases and is also faster.

Also just changed the variable `all_locations` to `sphere` because that's what they are

## How was this tested?

Generations and comparing spoiler logs before and after each of the changes.