### PR TITLE
Smooth Soul items by Size

### DIFF
--- a/worlds/dark_souls_3/__init__.py
+++ b/worlds/dark_souls_3/__init__.py
@@ -1455,10 +1455,12 @@ class DarkSouls3World(World):
             smooth_items([item for item in all_item_order if item.base_name in base_names])
 
         if self.options.smooth_soul_items:
-            smooth_items([
+            souls = [
                 item for item in all_item_order
                 if item.souls and item.classification != ItemClassification.progression
-            ])
+            ]
+            souls.sort(key=lambda item: item.souls)
+            smooth_items(souls)
 
         if self.options.smooth_upgraded_weapons:
             upgraded_weapons = [


### PR DESCRIPTION
## What is this fixing or adding?

Changes the way souls are smoothed to be strictly by size instead of when they are reached in a roughly vanilla playthrough

## How was this tested?

Generations and reading spoiler logs