### PR TITLE
Convert Smoothing to use remaining_fill

### DIFF
--- a/worlds/dark_souls_3/__init__.py
+++ b/worlds/dark_souls_3/__init__.py
@@ -1448,7 +1448,7 @@ class DarkSouls3World(World):
                 sorted_spheres.extend(onworld + offworld)
 
             converted_item_order.reverse()
-            remaining_fill(self.multiworld, sorted_spheres, converted_item_order, name="DS3 Smoothing")  # , check_location_can_fill=True)
+            remaining_fill(self.multiworld, sorted_spheres, converted_item_order, name="DS3 Smoothing", check_location_can_fill=True)
 
 
         if self.options.smooth_upgrade_items:


### PR DESCRIPTION
## What is this fixing or adding?

Uses `remaining_fill` instead of the `can_fill` and custom `_pop_item` methods.

## How was this tested?

Generations (including with both of the linked PRs) and reading the spoiler logs. The output before when Usefuls would not be placed on excluded locations were identical.


This is waiting on https://github.com/ArchipelagoMW/Archipelago/pull/3738 or https://github.com/ArchipelagoMW/Archipelago/pull/3739 because right now it could place Useful items (the Titanite Slabs and the four Coals) onto excluded locations.