### PR TITLE
Dark Souls III: Add statement about opening Steam from source folder

### DIFF
--- a/worlds/dark_souls_3/docs/setup_en.md
+++ b/worlds/dark_souls_3/docs/setup_en.md
@@ -124,7 +124,8 @@ find `DarkSoulsIII.exe` or to launch it properly. If this is happening to you, m
 
 * Steam is not running in administrator mode. To fix this, right-click `steam.exe` (by default this
   is in `C:\Program Files\Steam`), select "Properties", open the "Compatiblity" tab, and uncheck
-  "Run this program as an administrator".
+  "Run this program as an administrator". Try opening `steam.exe` directly from this folder if you were
+  using other means such as the taskbar.
 
 * There is no `dinput8.dll` file in your DS3 game directory. This is the old way of installing mods,
   and it can interfere with the new ModEngine2 workflow.


### PR DESCRIPTION
## What is this fixing or adding?
Added a statement in the FAQ to try opening steam.exe directly from the folder instead of doing something else like opening it from the taskbar which could leave it in admin mode.