### PR TITLE
Marking Morne's Set as not missable

### DIFF
--- a/worlds/dark_souls_3/Locations.py
+++ b/worlds/dark_souls_3/Locations.py
@@ -2080,7 +2080,7 @@ location_tables: Dict[str, List[DS3LocationData]] = {
         DS3LocationData("FS: Morne's Great Hammer - Eygon", "Morne's Great Hammer", npc=True),
         DS3LocationData("FS: Moaning Shield - Eygon", "Moaning Shield", npc=True),
 
-        # Shrine Handmaid after killing Dragonslayer Armour (or Eygon of Carim)
+        # Shrine Handmaid after killing Dancer of the Boreal Valley
         DS3LocationData("FS: Dancer's Crown - shop after killing LC entry boss", "Dancer's Crown",
                         boss=True, shop=True),
         DS3LocationData("FS: Dancer's Armor - shop after killing LC entry boss", "Dancer's Armor",
@@ -2092,13 +2092,13 @@ location_tables: Dict[str, List[DS3LocationData]] = {
 
         # Shrine Handmaid after killing Dragonslayer Armour (or Eygon of Carim)
         DS3LocationData("FS: Morne's Helm - shop after killing Eygon or LC boss", "Morne's Helm",
-                        boss=True, shop=True, missable=True),
+                        boss=True, shop=True),
         DS3LocationData("FS: Morne's Armor - shop after killing Eygon or LC boss", "Morne's Armor",
-                        boss=True, shop=True, missable=True),
+                        boss=True, shop=True),
         DS3LocationData("FS: Morne's Gauntlets - shop after killing Eygon or LC boss",
-                        "Morne's Gauntlets", boss=True, shop=True, missable=True),
+                        "Morne's Gauntlets", boss=True, shop=True),
         DS3LocationData("FS: Morne's Leggings - shop after killing Eygon or LC boss",
-                        "Morne's Leggings", boss=True, shop=True, missable=True),
+                        "Morne's Leggings", boss=True, shop=True),
     ],
     "Consumed King's Garden": [
         DS3LocationData("CKG: Soul of Consumed Oceiros", "Soul of Consumed Oceiros",

--- a/worlds/dark_souls_3/__init__.py
+++ b/worlds/dark_souls_3/__init__.py
@@ -711,7 +711,11 @@ class DarkSouls3World(World):
 
         self._add_location_rule([
             "FS: Morne's Great Hammer - Eygon",
-            "FS: Moaning Shield - Eygon"
+            "FS: Moaning Shield - Eygon",
+            "FS: Morne's Helm - shop after killing Eygon or LC boss",
+            "FS: Morne's Armor - shop after killing Eygon or LC boss",
+            "FS: Morne's Gauntlets - shop after killing Eygon or LC boss",
+            "FS: Morne's Leggings - shop after killing Eygon or LC boss"
         ], lambda state: (
             self._can_get(state, "LC: Soul of Dragonslayer Armour") and
             self._can_get(state, "FK: Soul of the Blood of the Wolf")


### PR DESCRIPTION
The morne's set is available after Eygon is dead and he dies either by the hands of the player or after you kill the Abyss Watchers and Dragonslayer Armour, that's why it was previously not working intended and items like Small Lothric Banner was unobtainable if it was put in one of the Morne's pieces, with this change the banner cannot be put there since it requires access to the Abyss Watchers.