### PR TITLE
Fix rules for DS3 world generation

### DIFF
--- a/worlds/dark_souls_3/__init__.py
+++ b/worlds/dark_souls_3/__init__.py
@@ -633,13 +633,7 @@ class DarkSouls3World(World):
             self._add_entrance_rule("Painted World of Ariandel (After Contraption)", "Contraption Key")
             self._add_entrance_rule(
                 "Dreg Heap",
-                lambda state: (
-                    self._can_get(state, "PW2: Soul of Sister Friede")
-                    or (
-                        {*self.options.goal} != {"Kiln of the First Flame Boss"}
-                        and self._can_go_to(state, "Kiln of the First Flame")
-                    )
-                ),
+                lambda state: self._can_get(state, "PW2: Soul of Sister Friede"),
                 from_region="Painted World of Ariandel (After Contraption)",
             )
             self._add_entrance_rule("Ringed City", lambda state: (
@@ -647,13 +641,26 @@ class DarkSouls3World(World):
                 and self._can_get(state, "DH: Soul of the Demon Prince")
             ))
 
+            is_goal_not_only_kiln_boss = {*self.options.goal} != {"Kiln of the First Flame Boss"}
+
             if self.options.late_dlc:
                 self._add_entrance_rule(
                     "Painted World of Ariandel (Before Contraption)",
                     lambda state: state.has("Small Doll", self.player) and self._has_any_scroll(state))
 
+                if is_goal_not_only_kiln_boss:
+                    self._add_entrance_rule(
+                        "Dreg Heap",
+                        lambda state: state.has("Small Doll", self.player) and self._has_any_scroll(state),
+                        from_region="Kiln of the First Flame",
+                    )
+
             if self.options.late_dlc > 1:  # After Basin
                 self._add_entrance_rule("Painted World of Ariandel (Before Contraption)", "Basin of Vows")
+
+                if is_goal_not_only_kiln_boss:
+                    self._add_entrance_rule("Dreg Heap", "Basin of Vows",
+                        from_region="Kiln of the First Flame")
 
         # Define the access rules to some specific locations
         self._add_location_rule("HWL: Red Eye Orb - wall tower, miniboss", "Lift Chamber Key")

--- a/worlds/dark_souls_3/__init__.py
+++ b/worlds/dark_souls_3/__init__.py
@@ -883,7 +883,6 @@ class DarkSouls3World(World):
             "FS: Hidden Blessing - Greirat from IBV",
             "FS: Titanite Scale - Greirat from IBV",
             "FS: Twinkling Titanite - Greirat from IBV",
-            "FS: Ember - shop for Greirat's Ashes"
         ], lambda state: (
             self._can_go_to(state, "Irithyll of the Boreal Valley")
             and self._can_get(state, "FS: Divine Blessing - Greirat from US")

--- a/worlds/dark_souls_3/__init__.py
+++ b/worlds/dark_souls_3/__init__.py
@@ -1044,8 +1044,8 @@ class DarkSouls3World(World):
             # quest is done
             "AL: Yorshka's Chime - kill Yorshka",
         ], lambda state: (
-            self._can_get(state, "US: Soul of the Rotted Greatwood")
-            and state.has("Dreamchaser's Ashes", self.player)
+            self._can_get(state, "FS: Budding Green Blossom - shop after killing Creighton and AL boss")
+            and self._can_get(state, "GA: Soul of the Twin Princes")
         ))
 
         ## Cornyx

--- a/worlds/dark_souls_3/__init__.py
+++ b/worlds/dark_souls_3/__init__.py
@@ -1062,15 +1062,6 @@ class DarkSouls3World(World):
             and state.has("Izalith Pyromancy Tome", self.player)
         ))
 
-        self._add_location_rule([
-            "US: Old Sage's Blindfold - kill Cornyx", "US: Cornyx's Garb - kill Cornyx",
-            "US: Cornyx's Wrap - kill Cornyx", "US: Cornyx's Skirt - kill Cornyx"
-        ], lambda state: (
-            state.has("Great Swamp Pyromancy Tome", self.player)
-            and state.has("Carthus Pyromancy Tome", self.player)
-            and state.has("Izalith Pyromancy Tome", self.player)
-        ))
-
         ## Irina
 
         self._add_location_rule([

--- a/worlds/dark_souls_3/__init__.py
+++ b/worlds/dark_souls_3/__init__.py
@@ -262,7 +262,7 @@ class DarkSouls3World(World):
             )
             create_connection("Dreg Heap", "Ringed City")
 
-            if self.options.goal != {"Kiln of the First Flame Boss"}:
+            if {*self.options.goal} != {"Kiln of the First Flame Boss"}:
                 create_connection("Kiln of the First Flame", "Dreg Heap", explicit_from=True)
 
     # For each region, add the associated locations retrieved from the corresponding location_table
@@ -636,7 +636,7 @@ class DarkSouls3World(World):
                 lambda state: (
                     self._can_get(state, "PW2: Soul of Sister Friede")
                     or (
-                        self.options.goal != {"Kiln of the First Flame Boss"}
+                        {*self.options.goal} != {"Kiln of the First Flame Boss"}
                         and self._can_go_to(state, "Kiln of the First Flame")
                     )
                 ),


### PR DESCRIPTION
## What is this fixing or adding?
This fixes the issues I found while going through the execution flow of `__init__.py`:
##### 1. [Remove duplicate rule](https://github.com/fswap/Archipelago/commit/f32afdc3ac9aa2946d6ccec9c78cab0d3a7fbc99)
- Issue was: self-explanatory, the same exact rule was above the removed rule.
##### 2. [Removes redundant rule](https://github.com/fswap/Archipelago/commit/adc95183c15fa9947ce7528ce9b7a1318d288743)
- Issue was: `This is not needed, because the next _add_location_rule is for this location ("FS: Ember - shop for Greirat's Ashes"), and it is set to depend on a location which is already in this list ("FS: Divine Blessing - Greirat from IBV").`
##### 3. [Fix conditions by converting options.goal to set](https://github.com/fswap/Archipelago/commit/9a8ad9c2e3b70e214e9c80ae9fe752ab4de2eaf8)
- Issue was: `options.goal` is derived from `OptionSet` which does not support `__eq__` / `__ne__`.
##### 4. [Fix condition for an _add_location_rule](https://github.com/fswap/Archipelago/commit/b864703e0ec8df833dc331a2fa5a864324e5ef03)
- Issue was: `This condition was probably copy-pasted, but the change was forgotten afterwards. Even the comment above this _add_location_rule states otherwise.`
##### 5. [Fix entrance rules for KFF => DH](https://github.com/fswap/Archipelago/commit/6f6411a1595b9b1a816704d41917d28644045dec)
- Issue was: `The issue was that DH could be reached without having Small Doll (and therefore it could had it), because there was no entrance rule for KFF => DH, only a wrongly added condition for PW2 => DH.`
- [[download example yaml](https://github.com/user-attachments/files/28905411/ds3_test.yaml)]
```yaml
# Only showing necessary settings to reproduce generation bug
Dark Souls III:
  goal:
  - Painted World of Ariandel End Boss # we want to ensure that Small Doll is only reachable through KFF
  late_dlc: 'after_small_doll' # the soft logic option, that doesn't work correctly (could be replaced with 'after_basin')
  enable_dlc: true
  exclude_locations: [] # we want to ensure that the plando works
  plando_items:
    - items:
        Cinders of a Lord - Abyss Watcher: 1
        Cinders of a Lord - Aldrich: 1
        Cinders of a Lord - Yhorm the Giant: 1
        Cinders of a Lord - Lothric Prince: 1
        Transposing Kiln: 1
      locations:
        'Cemetery of Ash' # get these items very early, which are necessary to get to KFF
      force: true # fail the generation, if items can't be placed to locations
    - items:
        Small Doll: 1
      locations:
        'Dreg Heap' # plando Small Doll here, even though late_dlc is not turned off
      force: true # fail the generation, if items can't be placed to locations
    - items:
        Contraption Key: 1
      locations:
        'Irithyll of the Boreal Valley' # ensure that PW2 End Boss is only reachable after Small Doll
      force: true # fail the generation, if items can't be placed to locations
```

## How was this tested?
##### 1. [Remove duplicate  rule](https://github.com/fswap/Archipelago/commit/f32afdc3ac9aa2946d6ccec9c78cab0d3a7fbc99)
- Because it's self-explanatory, it doesn't need one.
##### 2. [Removes redundant rule](https://github.com/fswap/Archipelago/commit/adc95183c15fa9947ce7528ce9b7a1318d288743)
- Can't be tested, but after examining the commit, the reason for the removal should be obvious with the above explanation.
##### 3. [Fix conditions by converting options.goal to set](https://github.com/fswap/Archipelago/commit/9a8ad9c2e3b70e214e9c80ae9fe752ab4de2eaf8)
- With debugging, I could check the program could enter the `if` block, if the goal was only KFF Boss. Previously, it couldn't.
##### 4. [Fix condition for an _add_location_rule](https://github.com/fswap/Archipelago/commit/b864703e0ec8df833dc331a2fa5a864324e5ef03)
- Can't be tested, *it just works*™️ .
##### 5. [Fix entrance rules for KFF => DH](https://github.com/fswap/Archipelago/commit/6f6411a1595b9b1a816704d41917d28644045dec)
- It only generates when the yaml above is changed to `late_dlc: 'off'`, otherwise it fails.